### PR TITLE
Get dependent views for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ interface TableReflectionInterface
     public function getPrimaryKeysNames(): array;
     public function getTableStats(): TableStatsInterface;
     public function isTemporary(): bool;
+    public function getDependentViews(): array;
 }
 ```
 
@@ -77,6 +78,16 @@ interface ColumnInterface
     public function getColumnName(): string;
     public function getColumnDefinition(): Keboola\Datatype\Definition\DefinitionInterface;
     public static function createGenericColumn(string $columnName): self;
+}
+```
+
+### Keboola\TableBackendUtils\View\ViewReflectionInterface
+
+Function to retrieve information's about view:
+```php
+interface ViewReflectionInterface
+{
+    public function getDependentViews(): array;
 }
 ```
 

--- a/src/Table/SynapseTableReflection.php
+++ b/src/Table/SynapseTableReflection.php
@@ -205,4 +205,23 @@ EOT
     {
         return $this->isTemporary;
     }
+
+    public function getDependentViews(): array
+    {
+        $sql = <<<EOT
+            SELECT schema_name(o.schema_id) schema_name, o.name
+            FROM sys.sql_expression_dependencies rel
+            JOIN sys.views o ON rel.referencing_id = o.object_id
+            WHERE
+                rel.referenced_id = object_id(N%s)
+EOT;
+        return $this->connection->fetchAll(sprintf(
+            $sql,
+            $this->connection->quote(sprintf(
+                '%s.%s',
+                $this->platform->quoteSingleIdentifier($this->schemaName),
+                $this->platform->quoteSingleIdentifier($this->tableName)
+            ))
+        ));
+    }
 }

--- a/src/Table/SynapseTableReflection.php
+++ b/src/Table/SynapseTableReflection.php
@@ -206,6 +206,12 @@ EOT
         return $this->isTemporary;
     }
 
+    /**
+     * @return array{
+     *  schema_name: string,
+     *  name: string
+     * }[]
+     */
     public function getDependentViews(): array
     {
         $sql = <<<EOT
@@ -215,7 +221,14 @@ EOT
             WHERE
                 rel.referenced_id = object_id(N%s)
 EOT;
-        return $this->connection->fetchAll(sprintf(
+
+        /**
+         * @var array{
+         *  schema_name: string,
+         *  name: string
+         * }[] $views
+         */
+        $views = $this->connection->fetchAll(sprintf(
             $sql,
             $this->connection->quote(sprintf(
                 '%s.%s',
@@ -223,5 +236,7 @@ EOT;
                 $this->platform->quoteSingleIdentifier($this->tableName)
             ))
         ));
+
+        return $views;
     }
 }

--- a/src/Table/TableReflectionInterface.php
+++ b/src/Table/TableReflectionInterface.php
@@ -25,4 +25,6 @@ interface TableReflectionInterface
     public function getTableStats(): TableStatsInterface;
 
     public function isTemporary(): bool;
+
+    public function getDependentViews(): array;
 }

--- a/src/Table/TableReflectionInterface.php
+++ b/src/Table/TableReflectionInterface.php
@@ -26,5 +26,11 @@ interface TableReflectionInterface
 
     public function isTemporary(): bool;
 
+    /**
+     * @return array{
+     *  schema_name: string,
+     *  name: string
+     * }[]
+     */
     public function getDependentViews(): array;
 }

--- a/src/View/SynapseViewReflection.php
+++ b/src/View/SynapseViewReflection.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\View;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Keboola\TableBackendUtils\Column\ColumnCollection;
+use Keboola\TableBackendUtils\Column\SynapseColumn;
+use Keboola\TableBackendUtils\ReflectionException;
+
+final class SynapseViewReflection implements ViewReflectionInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var string */
+    private $schemaName;
+
+    /** @var string */
+    private $viewName;
+
+    /** @var SQLServer2012Platform|AbstractPlatform */
+    private $platform;
+
+    public function __construct(Connection $connection, string $schemaName, string $viewName)
+    {
+        $this->viewName = $viewName;
+        $this->schemaName = $schemaName;
+        $this->connection = $connection;
+        $this->platform = $connection->getDatabasePlatform();
+    }
+
+    public function getDependentViews(): array
+    {
+        $sql = <<<EOT
+            SELECT schema_name(o.schema_id) schema_name, o.name
+            FROM sys.sql_expression_dependencies rel
+            JOIN sys.views o ON rel.referencing_id = o.object_id
+            WHERE
+                rel.referenced_id = object_id(N%s)
+EOT;
+        return $this->connection->fetchAll(sprintf(
+            $sql,
+            $this->connection->quote(sprintf(
+                '%s.%s',
+                $this->platform->quoteSingleIdentifier($this->schemaName),
+                $this->platform->quoteSingleIdentifier($this->viewName)
+            ))
+        ));
+    }
+}

--- a/src/View/SynapseViewReflection.php
+++ b/src/View/SynapseViewReflection.php
@@ -42,7 +42,13 @@ final class SynapseViewReflection implements ViewReflectionInterface
             WHERE
                 rel.referenced_id = object_id(N%s)
 EOT;
-        return $this->connection->fetchAll(sprintf(
+        /**
+         * @var array{
+         *  schema_name: string,
+         *  name: string
+         * }[] $views
+         */
+        $views = $this->connection->fetchAll(sprintf(
             $sql,
             $this->connection->quote(sprintf(
                 '%s.%s',
@@ -50,5 +56,7 @@ EOT;
                 $this->platform->quoteSingleIdentifier($this->viewName)
             ))
         ));
+
+        return $views;
     }
 }

--- a/src/View/ViewReflectionInterface.php
+++ b/src/View/ViewReflectionInterface.php
@@ -6,5 +6,11 @@ namespace Keboola\TableBackendUtils\View;
 
 interface ViewReflectionInterface
 {
+    /**
+     * @return array{
+     *  schema_name: string,
+     *  name: string
+     * }[]
+     */
     public function getDependentViews(): array;
 }

--- a/src/View/ViewReflectionInterface.php
+++ b/src/View/ViewReflectionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\View;
+
+interface ViewReflectionInterface
+{
+    public function getDependentViews(): array;
+}

--- a/tests/Functional/View/SynapseViewReflectionTest.php
+++ b/tests/Functional/View/SynapseViewReflectionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\TableBackendUtils\Functional\View;
+
+use Keboola\TableBackendUtils\View\SynapseViewReflection;
+use Tests\Keboola\TableBackendUtils\Functional\SynapseBaseCase;
+
+/**
+ * @covers SynapseViewReflection
+ */
+class SynapseViewReflectionTest extends SynapseBaseCase
+{
+    public const TEST_SCHEMA = self::TESTS_PREFIX . 'ref-table-schema';
+    // tables
+    public const TABLE_GENERIC = self::TESTS_PREFIX . 'ref';
+    //views
+    public const VIEW_GENERIC = self::TESTS_PREFIX . 'ref-view';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dropAllWithinSchema(self::TEST_SCHEMA);
+        $this->createTestSchema();
+    }
+
+    private function createTestSchema(): void
+    {
+        $this->connection->exec($this->schemaQb->getCreateSchemaCommand(self::TEST_SCHEMA));
+    }
+
+    public function testGetDependentViews(): void
+    {
+        $this->initTable();
+        $this->initView(self::VIEW_GENERIC, self::TABLE_GENERIC);
+
+        $ref = new SynapseViewReflection($this->connection, self::TEST_SCHEMA, self::VIEW_GENERIC);
+
+        $this->assertCount(0, $ref->getDependentViews());
+
+        $secondViewName = self::VIEW_GENERIC . '-2';
+        $this->initView($secondViewName, self::VIEW_GENERIC);
+
+        $dependentViews = $ref->getDependentViews();
+        $this->assertCount(1, $dependentViews);
+
+        $this->assertSame([
+            'schema_name' => self::TEST_SCHEMA,
+            'name' => $secondViewName,
+        ], $dependentViews[0]);
+    }
+
+    private function initTable(): void
+    {
+        $this->connection->exec(
+            sprintf(
+                'CREATE TABLE [%s].[%s] (
+          [int_def] INT NOT NULL DEFAULT 0,
+          [var_def] nvarchar(1000) NOT NULL DEFAULT (\'\'),
+          [num_def] NUMERIC(10,5) DEFAULT ((1.00)),
+          [_time] datetime2 NOT NULL DEFAULT \'2020-02-01 00:00:00\'
+        );',
+                self::TEST_SCHEMA,
+                self::TABLE_GENERIC
+            )
+        );
+    }
+
+    private function initView(string $viewName, string $parentName): void
+    {
+        $this->connection->exec(
+            sprintf(
+                'CREATE VIEW [%s].[%s] AS SELECT * FROM [%s].[%s];',
+                self::TEST_SCHEMA,
+                $viewName,
+                self::TEST_SCHEMA,
+                $parentName
+            )
+        );
+    }
+}


### PR DESCRIPTION
Vytáhl jsem to ven z https://github.com/keboola/connection/pull/2447

Nevím jestli na tu reprezentaci viewčka nezakládat zas nějaký objekt? Něco jako `ViewInfo`? Ale to by měla být obálka pouze nad tím schematem + názvem view. To mi přijde trochu zbytečný?