### PR TITLE
Synapse datatype uppercase + trim default value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "doctrine/dbal": "^2.9",
         "keboola/common-exceptions": "^1",
-        "keboola/php-datatypes": "4.7.*",
+        "keboola/php-datatypes": "^4.8",
         "keboola/php-utils": "^4.1"
     },
     "require-dev": {

--- a/src/Column/SynapseColumn.php
+++ b/src/Column/SynapseColumn.php
@@ -78,7 +78,7 @@ final class SynapseColumn implements ColumnInterface
             $default = preg_replace(
                 '/^\((.+)\)$/',
                 '\\1',
-                preg_replace(
+                (string) preg_replace(
                     '/^\(\((.+)\)\)$/',
                     '\\1',
                     $default

--- a/src/Table/SynapseTableQueryBuilder.php
+++ b/src/Table/SynapseTableQueryBuilder.php
@@ -68,7 +68,7 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         $columnsSql = [];
         foreach ($columns as $column) {
             if ($column->getColumnName() === ColumnInterface::TIMESTAMP_COLUMN_NAME) {
-                $columnsSql[] = sprintf('[%s] datetime2', ColumnInterface::TIMESTAMP_COLUMN_NAME);
+                $columnsSql[] = sprintf('[%s] DATETIME2', ColumnInterface::TIMESTAMP_COLUMN_NAME);
                 continue;
             }
             $columnsSql[] = sprintf(

--- a/tests/Functional/Table/SynapseTableQueryBuilderTest.php
+++ b/tests/Functional/Table/SynapseTableQueryBuilderTest.php
@@ -47,7 +47,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
 
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[#utils-test_test] ([col1] nvarchar(4000) NOT NULL DEFAULT \'\', [col2] nvarchar(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
+            'CREATE TABLE [utils-test_qb-schema].[#utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
             $sql
         );
         $this->connection->exec($sql);
@@ -73,7 +73,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] nvarchar(4000) NOT NULL DEFAULT \'\', [col2] nvarchar(4000) NOT NULL DEFAULT \'\')',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\')',
             $sql
         );
         $this->connection->exec($sql);
@@ -104,7 +104,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] nvarchar(4000) NOT NULL DEFAULT \'\', [col2] nvarchar(4000) NOT NULL DEFAULT \'\', [_timestamp] datetime2)',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_timestamp] DATETIME2)',
             $sql
         );
         $this->connection->exec($sql);
@@ -131,7 +131,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         );
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([pk1] int, [col1] nvarchar(4000) NOT NULL DEFAULT \'\', [col2] nvarchar(4000) NOT NULL DEFAULT \'\', [_timestamp] datetime2, PRIMARY KEY NONCLUSTERED([pk1],[col1]) NOT ENFORCED)',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([pk1] INT, [col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_timestamp] DATETIME2, PRIMARY KEY NONCLUSTERED([pk1],[col1]) NOT ENFORCED)',
             $sql
         );
         $this->connection->exec($sql);

--- a/tests/Functional/Table/SynapseTableReflectionTest.php
+++ b/tests/Functional/Table/SynapseTableReflectionTest.php
@@ -116,296 +116,304 @@ class SynapseTableReflectionTest extends SynapseBaseCase
     {
         yield 'INT NOT NULL DEFAULT 0' => [
             'int NOT NULL DEFAULT ((0))',
+            'INT NOT NULL DEFAULT 0',
+            'INT',
+            '0',
+            null,
+            false,
+        ];
+        yield 'INT DEFAULT NULL' => [
             'int NOT NULL DEFAULT ((0))',
-            'int',
-            '((0))',
+            'INT NOT NULL DEFAULT 0',
+            'INT',
+            '0',
             null,
             false,
         ];
         yield 'nvarchar(1000) NOT NULL DEFAULT (\'\')' => [
             'nvarchar(1000) NOT NULL DEFAULT (\'\')',
-            'nvarchar(1000) NOT NULL DEFAULT (\'\')',
-            'nvarchar',
-            '(\'\')',
+            'NVARCHAR(1000) NOT NULL DEFAULT \'\'',
+            'NVARCHAR',
+            '\'\'',
             '1000',
             false,
         ];
         yield 'NUMERIC(10,5) DEFAULT ((1.00))' => [
             'numeric(10,5) DEFAULT ((1.00))',
-            'numeric(10,5) DEFAULT ((1.00))',
-            'numeric',
-            '((1.00))',
+            'NUMERIC(10,5) DEFAULT 1.00',
+            'NUMERIC',
+            '1.00',
             '10,5',
             false,
         ];
         yield 'float' => [
             'float',
-            'float(53)',
-            'float',
+            'FLOAT(53)',
+            'FLOAT',
             null,
             '53',
             false,
         ];
         yield 'float(1)' => [
-            'float(1)',
-            'real',
-            'real',
+            'FLOAT(1)',
+            'REAL',
+            'REAL',
             null,
             null,
             false,
         ];
         yield 'float(20)' => [
             'float(20)',
-            'real',
-            'real',
+            'REAL',
+            'REAL',
             null,
             null,
             false,
         ];
         yield 'float(53)' => [
             'float(53)',
-            'float(53)',
-            'float',
+            'FLOAT(53)',
+            'FLOAT',
             null,
             '53',
             false,
         ];
         yield 'nvarchar' => [
             'nvarchar',
-            'nvarchar(1)',
-            'nvarchar',
+            'NVARCHAR(1)',
+            'NVARCHAR',
             null,
             '1',
             false,
         ];
         yield 'nvarchar(1)' => [
             'nvarchar(1)',
-            'nvarchar(1)',
-            'nvarchar',
+            'NVARCHAR(1)',
+            'NVARCHAR',
             null,
             '1',
             false,
         ];
         yield 'nvarchar(4000)' => [
             'nvarchar(4000)',
-            'nvarchar(4000)',
-            'nvarchar',
+            'NVARCHAR(4000)',
+            'NVARCHAR',
             null,
             '4000',
             false,
         ];
         yield 'nvarchar(max)' => [
             'nvarchar(max)',
-            'nvarchar(max)',
-            'nvarchar',
+            'NVARCHAR(MAX)',
+            'NVARCHAR',
             null,
-            'max',
+            'MAX',
             true,
         ];
         yield 'nchar' => [
             'nchar',
-            'nchar(1)',
-            'nchar',
+            'NCHAR(1)',
+            'NCHAR',
             null,
             '1',
             false,
         ];
         yield 'nchar(1)' => [
             'nchar(1)',
-            'nchar(1)',
-            'nchar',
+            'NCHAR(1)',
+            'NCHAR',
             null,
             '1',
             false,
         ];
         yield 'nchar(4000)' => [
             'nchar(4000)',
-            'nchar(4000)',
-            'nchar',
+            'NCHAR(4000)',
+            'NCHAR',
             null,
             '4000',
             false,
         ];
         yield 'varchar' => [
             'varchar',
-            'varchar(1)',
-            'varchar',
+            'VARCHAR(1)',
+            'VARCHAR',
             null,
             '1',
             false,
         ];
         yield 'varchar(1)' => [
             'varchar(1)',
-            'varchar(1)',
-            'varchar',
+            'VARCHAR(1)',
+            'VARCHAR',
             null,
             '1',
             false,
         ];
         yield 'varchar(8000)' => [
             'varchar(8000)',
-            'varchar(8000)',
-            'varchar',
+            'VARCHAR(8000)',
+            'VARCHAR',
             null,
             '8000',
             false,
         ];
         yield 'varchar(max)' => [
             'varchar(max)',
-            'varchar(max)',
-            'varchar',
+            'VARCHAR(MAX)',
+            'VARCHAR',
             null,
-            'max',
+            'MAX',
             true,
         ];
         yield 'char' => [
             'char',
-            'char(1)',
-            'char',
+            'CHAR(1)',
+            'CHAR',
             null,
             '1',
             false,
         ];
         yield 'char(1)' => [
             'char(1)',
-            'char(1)',
-            'char',
+            'CHAR(1)',
+            'CHAR',
             null,
             '1',
             false,
         ];
         yield 'char(4000)' => [
             'char(4000)',
-            'char(4000)',
-            'char',
+            'CHAR(4000)',
+            'CHAR',
             null,
             '4000',
             false,
         ];
         yield 'varbinary' => [
             'varbinary',
-            'varbinary(1)',
-            'varbinary',
+            'VARBINARY(1)',
+            'VARBINARY',
             null,
             '1',
             false,
         ];
         yield 'varbinary(1)' => [
             'varbinary(1)',
-            'varbinary(1)',
-            'varbinary',
+            'VARBINARY(1)',
+            'VARBINARY',
             null,
             '1',
             false,
         ];
         yield 'varbinary(8000)' => [
             'varbinary(8000)',
-            'varbinary(8000)',
-            'varbinary',
+            'VARBINARY(8000)',
+            'VARBINARY',
             null,
             '8000',
             false,
         ];
         yield 'varbinary(max)' => [
             'varbinary(max)',
-            'varbinary(max)',
-            'varbinary',
+            'VARBINARY(MAX)',
+            'VARBINARY',
             null,
-            'max',
+            'MAX',
             true,
         ];
         yield 'binary' => [
             'binary',
-            'binary(1)',
-            'binary',
+            'BINARY(1)',
+            'BINARY',
             null,
             '1',
             false,
         ];
         yield 'binary(1)' => [
             'binary(1)',
-            'binary(1)',
-            'binary',
+            'BINARY(1)',
+            'BINARY',
             null,
             '1',
             false,
         ];
         yield 'binary(8000)' => [
             'binary(8000)',
-            'binary(8000)',
-            'binary',
+            'BINARY(8000)',
+            'BINARY',
             null,
             '8000',
             false,
         ];
         yield 'datetimeoffset' => [
             'datetimeoffset',
-            'datetimeoffset(7)',
-            'datetimeoffset',
+            'DATETIMEOFFSET(7)',
+            'DATETIMEOFFSET',
             null,
             '7',
             false,
         ];
         yield 'datetimeoffset(0)' => [
             'datetimeoffset(0)',
-            'datetimeoffset(0)',
-            'datetimeoffset',
+            'DATETIMEOFFSET(0)',
+            'DATETIMEOFFSET',
             null,
             '0',
             false,
         ];
         yield 'datetimeoffset(7)' => [
             'datetimeoffset(7)',
-            'datetimeoffset(7)',
-            'datetimeoffset',
+            'DATETIMEOFFSET(7)',
+            'DATETIMEOFFSET',
             null,
             '7',
             false,
         ];
         yield 'datetime2' => [
             'datetime2',
-            'datetime2(7)',
-            'datetime2',
+            'DATETIME2(7)',
+            'DATETIME2',
             null,
             '7',
             false,
         ];
         yield 'datetime2(0)' => [
             'datetime2(0)',
-            'datetime2(0)',
-            'datetime2',
+            'DATETIME2(0)',
+            'DATETIME2',
             null,
             '0',
             false,
         ];
         yield 'datetime2(7)' => [
             'datetime2(7)',
-            'datetime2(7)',
-            'datetime2',
+            'DATETIME2(7)',
+            'DATETIME2',
             null,
             '7',
             false,
         ];
         yield 'time' => [
             'time',
-            'time(7)',
-            'time',
+            'TIME(7)',
+            'TIME',
             null,
             '7',
             false,
         ];
         yield 'time(0)' => [
             'time(0)',
-            'time(0)',
-            'time',
+            'TIME(0)',
+            'TIME',
             null,
             '0',
             false,
         ];
         yield 'time(7)' => [
             'time(7)',
-            'time(7)',
-            'time',
+            'TIME(7)',
+            'TIME',
             null,
             '7',
             false,

--- a/tests/Unit/Column/SynapseColumnTest.php
+++ b/tests/Unit/Column/SynapseColumnTest.php
@@ -22,11 +22,11 @@ class SynapseColumnTest extends TestCase
             'column_length' => 'whatever',
             'column_scale' => 'whatever',
             'column_is_nullable' => 'true',
-            'column_default' => 'NOW()',
+            'column_default' => '(NOW())',
         ]);
         $this->assertEquals('myCol', $col->getColumnName());
-        $this->assertEquals('datetime NOT NULL DEFAULT NOW()', $col->getColumnDefinition()->getSQLDefinition());
-        $this->assertEquals('datetime', $col->getColumnDefinition()->getType());
+        $this->assertEquals('DATETIME NOT NULL DEFAULT NOW()', $col->getColumnDefinition()->getSQLDefinition());
+        $this->assertEquals('DATETIME', $col->getColumnDefinition()->getType());
         $this->assertEquals('NOW()', $col->getColumnDefinition()->getDefault());
         $this->assertEquals(null, $col->getColumnDefinition()->getLength());
     }
@@ -43,8 +43,8 @@ class SynapseColumnTest extends TestCase
             'column_default' => null,
         ]);
         $this->assertEquals('myCol', $col->getColumnName());
-        $this->assertEquals('nvarchar(2000) NOT NULL', $col->getColumnDefinition()->getSQLDefinition());
-        $this->assertEquals('nvarchar', $col->getColumnDefinition()->getType());
+        $this->assertEquals('NVARCHAR(2000) NOT NULL', $col->getColumnDefinition()->getSQLDefinition());
+        $this->assertEquals('NVARCHAR', $col->getColumnDefinition()->getType());
         $this->assertEquals('', $col->getColumnDefinition()->getDefault());
         $this->assertEquals('2000', $col->getColumnDefinition()->getLength());
     }
@@ -58,11 +58,11 @@ class SynapseColumnTest extends TestCase
             'column_length' => 'whatever',
             'column_scale' => '10',
             'column_is_nullable' => 'true',
-            'column_default' => '1',
+            'column_default' => '((1))',
         ]);
         $this->assertEquals('myCol', $col->getColumnName());
-        $this->assertEquals('decimal(20,10) NOT NULL DEFAULT 1', $col->getColumnDefinition()->getSQLDefinition());
-        $this->assertEquals('decimal', $col->getColumnDefinition()->getType());
+        $this->assertEquals('DECIMAL(20,10) NOT NULL DEFAULT 1', $col->getColumnDefinition()->getSQLDefinition());
+        $this->assertEquals('DECIMAL', $col->getColumnDefinition()->getType());
         $this->assertEquals('1', $col->getColumnDefinition()->getDefault());
         $this->assertEquals('20,10', $col->getColumnDefinition()->getLength());
     }
@@ -71,8 +71,8 @@ class SynapseColumnTest extends TestCase
     {
         $col = SynapseColumn::createGenericColumn('myCol');
         $this->assertEquals('myCol', $col->getColumnName());
-        $this->assertEquals('nvarchar(4000) NOT NULL DEFAULT \'\'', $col->getColumnDefinition()->getSQLDefinition());
-        $this->assertEquals('nvarchar', $col->getColumnDefinition()->getType());
+        $this->assertEquals('NVARCHAR(4000) NOT NULL DEFAULT \'\'', $col->getColumnDefinition()->getSQLDefinition());
+        $this->assertEquals('NVARCHAR', $col->getColumnDefinition()->getType());
         $this->assertEquals('\'\'', $col->getColumnDefinition()->getDefault());
         $this->assertEquals('4000', $col->getColumnDefinition()->getLength());
     }


### PR DESCRIPTION
SynapseColumn
- datatype uppercase
- trim brackets from column default value
```
  (NULL) => NULL
  (`test`) => `test`
  ((123)) => 123
  (FUNCTION()) => FUNCTION()
```