### PR TITLE
KBC-1372 new methods for SynapseViewReflection getViewDefinition, refreshView

### DIFF
--- a/src/View/InvalidViewDefinitionException.php
+++ b/src/View/InvalidViewDefinitionException.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\View;
+
+use Keboola\CommonExceptions\ApplicationExceptionInterface;
+use RuntimeException;
+use Throwable;
+
+class InvalidViewDefinitionException extends RuntimeException implements ApplicationExceptionInterface
+{
+    public function __construct(string $message, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public static function createForMissingDefinition(
+        string $schemaName,
+        string $viewName
+    ): InvalidViewDefinitionException {
+        return new self(
+            sprintf(
+                'Definition of view "%s" in schema "%s"cannot be obtained from Synapse or it\'s invalid.',
+                $viewName,
+                $schemaName
+            )
+        );
+    }
+
+    public static function createViewRefreshError(
+        string $schemaName,
+        string $viewName,
+        Throwable $previous
+    ): InvalidViewDefinitionException {
+        return new self(
+            sprintf(
+                'View "%s" in schema "%s" has to be refreshed manually, since it\'s definition cannot be refreshed.',
+                $viewName,
+                $schemaName
+            ),
+            $previous
+        );
+    }
+}

--- a/src/View/SynapseViewReflection.php
+++ b/src/View/SynapseViewReflection.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Keboola\TableBackendUtils\View;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
-use Keboola\TableBackendUtils\Column\ColumnCollection;
-use Keboola\TableBackendUtils\Column\SynapseColumn;
-use Keboola\TableBackendUtils\ReflectionException;
 
 final class SynapseViewReflection implements ViewReflectionInterface
 {
@@ -65,5 +63,48 @@ final class SynapseViewReflection implements ViewReflectionInterface
         }
 
         return $dependencies;
+    }
+
+    /**
+     * if definition is longer than 4000characters, function will throw exception and user has to create view on its own
+     */
+    public function getViewDefinition(): string
+    {
+        $sql = sprintf(
+            'SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+            $this->connection->quote($this->schemaName),
+            $this->connection->quote($this->viewName)
+        );
+
+        $definition = $this->connection->fetchColumn($sql);
+        $isValid = preg_match('/CREATE[\s\S]*VIEW[\s\S]*AS[\s\S]*SELECT[\s\S]*FROM[\s\S]*/', $definition);
+        if ($isValid === 0) {
+            throw InvalidViewDefinitionException::createForMissingDefinition($this->schemaName, $this->viewName);
+        }
+
+        return $definition;
+    }
+
+    /**
+     * in general there is stored procedure sp_refreshview in mssql but this is not available in synapse
+     * function is using INFORMATION_SCHEMA.VIEWS[VIEW_DEFINITION] to recreate view
+     * if definition is longer than 4000characters, function will throw exception and user has to create view on its own
+     */
+    public function refreshView(): void
+    {
+        $definition = $this->getViewDefinition();
+
+        $objectNameWithSchema = sprintf(
+            '%s.%s',
+            $this->platform->quoteSingleIdentifier($this->schemaName),
+            $this->platform->quoteSingleIdentifier($this->viewName)
+        );
+
+        $this->connection->exec(sprintf('DROP VIEW %s', $objectNameWithSchema));
+        try {
+            $this->connection->exec($definition);
+        } catch (DBALException $e) {
+            throw InvalidViewDefinitionException::createViewRefreshError($this->schemaName, $this->viewName, $e);
+        }
     }
 }


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-1372

- je tam jeden edge case, synapse navzdory dokumentaci má ve `VIEW_DEFINITION` zkrácenou definici pokud přesáhne 4000zn (podle dokumentace tam má být null) proto se kontroluje VIEW_DEFINITION regexem (navíc tam jsou reálně newlines přímo v definici) edcase je, že definici to vrátí zkrácnou pokud ke zkrácení dojde za FROM statementem.