### PR TITLE
new interface for escaping strings and synapse implementation

### DIFF
--- a/src/Escaping/QuoteInterface.php
+++ b/src/Escaping/QuoteInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Escaping;
+
+interface QuoteInterface
+{
+    public static function quote(string $value): string;
+
+    public static function quoteSingleIdentifier(string $str): string;
+}

--- a/src/Escaping/SynapseQuote.php
+++ b/src/Escaping/SynapseQuote.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Escaping;
+
+class SynapseQuote implements QuoteInterface
+{
+    public static function quote(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+
+    public static function quoteSingleIdentifier(string $str): string
+    {
+        return '[' . str_replace(']', '][', $str) . ']';
+    }
+}

--- a/tests/Unit/Escaping/SynapseQuoteTest.php
+++ b/tests/Unit/Escaping/SynapseQuoteTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\TableBackendUtils\Unit\Escaping;
+
+use Keboola\TableBackendUtils\Escaping\SynapseQuote;
+use PHPUnit\Framework\TestCase;
+
+class SynapseQuoteTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array<int, string>>
+     */
+    public function valueQuoteProvider(): \Generator
+    {
+        yield 'simple' => [
+            'valueToQuote',
+            '\'valueToQuote\'',
+        ];
+        yield 'with escaping char' => [
+            'value\'To\'Quote',
+            '\'value\'\'To\'\'Quote\'',
+        ];
+        yield 'complex' => [
+            'va[l.u]e\']To\'[Q][uo.t[]e',
+            '\'va[l.u]e\'\']To\'\'[Q][uo.t[]e\'',
+        ];
+    }
+
+    /**
+     * @dataProvider valueQuoteProvider
+     */
+    public function testQuote(string $value, string $expectedOutput): void
+    {
+        self::assertSame($expectedOutput, SynapseQuote::quote($value));
+    }
+
+    /**
+     * @return \Generator<string, array<int, string>>
+     */
+    public function valueQuoteIdentifierProvider(): \Generator
+    {
+        yield 'simple' => [
+            'valueToQuote',
+            '[valueToQuote]',
+        ];
+        yield 'with escaping char' => [
+            'value\'To\'Quote',
+            '[value\'To\'Quote]',
+        ];
+        yield 'complex' => [
+            'va[l.u]e\']To\'[Q][uo.t[]e',
+            '[va[l.u][e\'][To\'[Q][[uo.t[][e]',
+        ];
+    }
+
+
+    /**
+     * @dataProvider valueQuoteIdentifierProvider
+     */
+    public function testQuoteSingleIdentifier(string $value, string $expectedOutput): void
+    {
+        self::assertSame($expectedOutput, SynapseQuote::quoteSingleIdentifier($value));
+    }
+}


### PR DESCRIPTION
It's supper annoying injecting always doctrine connection to get platform and be able to quote.
- new `Keboola\TableBackendUtils\Escaping\QuoteInterface::{quote,quoteSingleIdentifier}` naming is same as in doctrine
