### PR TITLE
don't throw exception when PK column is nullable

### DIFF
--- a/src/Table/Exasol/ExasolTableQueryBuilder.php
+++ b/src/Table/Exasol/ExasolTableQueryBuilder.php
@@ -73,15 +73,6 @@ class ExasolTableQueryBuilder implements TableQueryBuilderInterface
             /** @var Exasol $columnDefinition */
             $columnDefinition = $column->getColumnDefinition();
 
-            // check if PK can be defined on selected columns
-            if ($primaryKeys && in_array($columnName, $primaryKeys, true)
-                && $columnDefinition->isNullable()) {
-                throw new QueryBuilderException(
-                    sprintf('Trying to set PK on column %s but this column is nullable', $columnName),
-                    self::INVALID_PKS_FOR_TABLE
-                );
-            }
-
             $columnsSqlDefinitions[] = sprintf(
                 '%s %s',
                 ExasolQuote::quoteSingleIdentifier($columnName),

--- a/tests/Functional/Table/Exasol/ExasolTableQueryBuilderTest.php
+++ b/tests/Functional/Table/Exasol/ExasolTableQueryBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Keboola\TableBackendUtils\Functional\Table\Exasol;
 
 use Doctrine\DBAL\Exception as DBALException;
+use Keboola\Datatype\Definition\Exasol;
 use Keboola\TableBackendUtils\Column\ColumnCollection;
 use Keboola\TableBackendUtils\Column\Exasol\ExasolColumn;
 use Keboola\TableBackendUtils\Table\Exasol\ExasolTableDefinition;
@@ -187,6 +188,34 @@ CREATE TABLE "$testDb"."$tableName"
 "col1" VARCHAR (2000000) DEFAULT '' NOT NULL,
 "col2" VARCHAR (2000000) DEFAULT '' NOT NULL,
 CONSTRAINT PRIMARY KEY ("col1","col2")
+);
+EOT
+            ,
+        ];
+
+        yield 'pk nullable' => [
+            'cols' => [
+                new ExasolColumn(
+                    'col1',
+                    new Exasol(
+                        Exasol::TYPE_VARCHAR,
+                        [
+                            'length' => '2000000',
+                            'nullable' => true,
+                        ]
+                    )
+                ),
+                ExasolColumn::createGenericColumn('col2'),
+            ],
+            'primaryKeys' => ['col1'],
+            'expectedColumnNames' => ['col1', 'col2'],
+            'expectedPrimaryKeys' => ['col1'],
+            'query' => <<<EOT
+CREATE TABLE "$testDb"."$tableName"
+(
+"col1" VARCHAR (2000000),
+"col2" VARCHAR (2000000) DEFAULT '' NOT NULL,
+CONSTRAINT PRIMARY KEY ("col1")
 );
 EOT
             ,

--- a/tests/Unit/Table/Exasol/ExasolTableQueryBuilderTest.php
+++ b/tests/Unit/Table/Exasol/ExasolTableQueryBuilderTest.php
@@ -53,12 +53,5 @@ class ExasolTableQueryBuilderTest extends TestCase
             'primaryKeys' => ['colNotExisting'],
             'exceptionString' => 'Trying to set colNotExisting as PKs but not present in columns',
         ];
-        yield 'pk on nullable type' => [
-            'cols' => [
-                new ExasolColumn('col1', new Exasol(Exasol::TYPE_VARCHAR, ['nullable' => true])),
-            ],
-            'primaryKeys' => ['col1'],
-            'exceptionString' => 'Trying to set PK on column col1 but this column is nullable',
-        ];
     }
 }


### PR DESCRIPTION
Tady to bysme neměli vůbec kontrolovat v kódu exasol to dovolí a přidá si tam constraint při přidání PK.