### PR TITLE
Update version of DBAL because lib uses new methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "^2.13",
         "keboola/common-exceptions": "^1",
         "keboola/php-datatypes": "^4.11.0",
         "keboola/php-utils": "^4.1"


### PR DESCRIPTION
Storage client was suffering from having old version of DBAL and it was calling some methods which werent present in 2.9 version. It was working in Connection because of updat of composer.lock