### PR TITLE
drop PDO for Teradata

### DIFF
--- a/src/Connection/Teradata/Result.php
+++ b/src/Connection/Teradata/Result.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Connection\Teradata;
+
+use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+
+class Result implements ResultInterface
+{
+    private const FETCH_ASSOCIATIVE = 'FETCH_ASSOCIATIVE';
+    private const FETCH_NUMERIC = 'FETCH_NUMERIC';
+
+    /** @var resource */
+    private $statement;
+
+    /**
+     * @param resource $statement
+     */
+    public function __construct($statement)
+    {
+        $this->statement = $statement;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchNumeric()
+    {
+        return $this->fetch(self::FETCH_NUMERIC);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchAssociative()
+    {
+        return $this->fetch(self::FETCH_ASSOCIATIVE);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchOne()
+    {
+        return FetchUtils::fetchOne($this);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchAllNumeric(): array
+    {
+        return FetchUtils::fetchAllNumeric($this);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchAllAssociative(): array
+    {
+        return FetchUtils::fetchAllAssociative($this);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchFirstColumn(): array
+    {
+        return FetchUtils::fetchFirstColumn($this);
+    }
+
+    public function rowCount(): int
+    {
+        return odbc_num_rows($this->statement);
+    }
+
+    public function columnCount(): int
+    {
+        return odbc_num_fields($this->statement);
+    }
+
+    public function free(): void
+    {
+        odbc_free_result($this->statement);
+    }
+
+    /**
+     * @param self::FETCH_* $fetchMode
+     * @return array<mixed>|false
+     */
+    private function fetch(string $fetchMode)
+    {
+        if (!odbc_fetch_row($this->statement)) {
+            return false;
+        }
+        $numFields = odbc_num_fields($this->statement);
+        $row = [];
+        switch ($fetchMode) {
+            case self::FETCH_ASSOCIATIVE:
+                for ($i = 1; $i <= $numFields; $i++) {
+                    $row[odbc_field_name($this->statement, $i)] = odbc_result($this->statement, $i);
+                }
+                break;
+
+            case self::FETCH_NUMERIC:
+                for ($i = 1; $i <= $numFields; $i++) {
+                    $row[] = odbc_result($this->statement, $i);
+                }
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Unsupported fetch mode "%s"', $fetchMode));
+        }
+
+        return $row;
+    }
+}

--- a/src/Connection/Teradata/TeradataConnectionWrapper.php
+++ b/src/Connection/Teradata/TeradataConnectionWrapper.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Connection\Teradata;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\ParameterType;
+use Exception;
+use Keboola\TableBackendUtils\Connection\Snowflake\Exception\DriverException;
+use Keboola\TableBackendUtils\Escaping\Snowflake\SnowflakeQuote;
+
+class TeradataConnectionWrapper implements Connection
+{
+    /** @var resource */
+    private $conn;
+
+    public function __construct(
+        string $dsn,
+        string $user,
+        string $password
+    ) {
+        try {
+            $handle = odbc_connect($dsn, $user, $password);
+            assert($handle !== false);
+            $this->conn = $handle;
+        } catch (\Throwable $e) {
+            throw DriverException::newConnectionFailure($e->getMessage(), (int) $e->getCode(), $e->getPrevious());
+        }
+    }
+
+    public function query(string $sql): Result
+    {
+        $stmt = $this->prepare($sql);
+        return $stmt->execute();
+    }
+
+    public function prepare(string $sql): TeradataStatement
+    {
+        return new TeradataStatement($this->conn, $sql);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quote($value, $type = ParameterType::STRING): string
+    {
+        return SnowflakeQuote::quote($value);
+    }
+
+    public function exec(string $sql): int
+    {
+        $stmt = $this->prepare($sql);
+        $result = $stmt->execute();
+
+        return $result->rowCount();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function lastInsertId($name = null)
+    {
+        // TODO: Implement lastInsertId() method.
+        throw new Exception('method is not implemented yet');
+    }
+
+    public function beginTransaction(): bool
+    {
+        if ($this->inTransaction()) {
+            throw new DriverException('There is already an active transaction');
+        }
+        return odbc_autocommit($this->conn, false);
+    }
+
+
+    private function inTransaction(): bool
+    {
+        return !odbc_autocommit($this->conn);
+    }
+
+    public function commit(): bool
+    {
+        if (!$this->inTransaction()) {
+            throw new DriverException('There is no active transaction');
+        }
+        return odbc_commit($this->conn) && odbc_autocommit($this->conn, true);
+    }
+
+    public function rollBack(): bool
+    {
+        if (!$this->inTransaction()) {
+            throw new DriverException('There is no active transaction');
+        }
+        return odbc_rollback($this->conn) && odbc_autocommit($this->conn, true);
+    }
+
+    public function errorCode(): ?string
+    {
+        return odbc_error($this->conn);
+    }
+
+    /**
+     * @inheritDoc
+     * @return array{code:string, message:string}
+     */
+    public function errorInfo(): array
+    {
+        return [
+            'code' => odbc_error($this->conn),
+            'message' => odbc_errormsg($this->conn),
+        ];
+    }
+
+    public function __destruct()
+    {
+        if (is_resource($this->conn)) {
+            odbc_close($this->conn);
+        }
+    }
+}

--- a/src/Connection/Teradata/TeradataRetryPolicy.php
+++ b/src/Connection/Teradata/TeradataRetryPolicy.php
@@ -22,8 +22,8 @@ class TeradataRetryPolicy extends AbstractRetryPolicy
             return $context->getRetryCount() === 0;
         }
 
-        foreach (self::PATTERNS as $pattern){
-            $pattern = '/'.$pattern.'/';
+        foreach (self::PATTERNS as $pattern) {
+            $pattern = '/' . $pattern . '/';
             $matches = null;
             if (preg_match($pattern, $e->getMessage(), $matches)) {
                 return true;

--- a/src/Connection/Teradata/TeradataRetryPolicy.php
+++ b/src/Connection/Teradata/TeradataRetryPolicy.php
@@ -9,6 +9,10 @@ use Retry\RetryContextInterface;
 
 class TeradataRetryPolicy extends AbstractRetryPolicy
 {
+    private const PATTERNS = [
+        'Concurrent change conflict on database -- try again',
+        'Connection reset by peer',
+    ];
     public function canRetry(RetryContextInterface $context): bool
     {
         $e = $context->getLastException();
@@ -16,10 +20,12 @@ class TeradataRetryPolicy extends AbstractRetryPolicy
             return $context->getRetryCount() === 0;
         }
 
-        $pattern = '/Concurrent change conflict on database -- try again/';
-        $matches = null;
-        if (preg_match($pattern, $e->getMessage(), $matches)) {
-            return true;
+        foreach (self::PATTERNS as $pattern){
+            $pattern = '/'.$pattern.'/';
+            $matches = null;
+            if (preg_match($pattern, $e->getMessage(), $matches)) {
+                return true;
+            }
         }
 
         return false;

--- a/src/Connection/Teradata/TeradataRetryPolicy.php
+++ b/src/Connection/Teradata/TeradataRetryPolicy.php
@@ -12,6 +12,8 @@ class TeradataRetryPolicy extends AbstractRetryPolicy
     private const PATTERNS = [
         'Concurrent change conflict on database -- try again',
         'Connection reset by peer',
+        'Neither TLS port nor Legacy Port has any response',
+        'TLS connection failed',
     ];
     public function canRetry(RetryContextInterface $context): bool
     {

--- a/src/Connection/Teradata/TeradataStatement.php
+++ b/src/Connection/Teradata/TeradataStatement.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Connection\Teradata;
+
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use Keboola\TableBackendUtils\Connection\Snowflake\Exception\DriverException;
+
+class TeradataStatement implements Statement
+{
+    /**
+     * @var resource
+     */
+    private $dbh;
+
+    /**
+     * @var resource
+     */
+    private $stmt;
+
+    /**
+     * @var array<mixed>
+     */
+    private $params = [];
+
+    private string $query;
+
+    /**
+     * @param resource $dbh database handle
+     * @param string $query
+     */
+    public function __construct($dbh, string $query)
+    {
+        $this->dbh = $dbh;
+        $this->query = $query;
+        $this->stmt = $this->prepare();
+    }
+
+    /**
+     * @return resource
+     */
+    private function prepare()
+    {
+        $stmt = @odbc_prepare($this->dbh, $this->query);
+        if (!$stmt) {
+            throw DriverException::newFromHandle($this->dbh);
+        }
+        return $stmt;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    {
+        return $this->bindParam($param, $value, $type);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
+    {
+        $this->params[$param] = &$variable;
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($params = null): Result
+    {
+        if (!empty($params) && is_array($params)) {
+            foreach ($params as $pos => $value) {
+                if (is_int($pos)) {
+                    $pos += 1;
+                }
+                $this->bindValue($pos, $value);
+            }
+        }
+
+        try {
+            odbc_execute($this->stmt, $this->repairBinding($this->params));
+        } catch (\Throwable $e) {
+            throw DriverException::newFromHandle($this->dbh);
+        }
+
+        return new Result($this->stmt);
+    }
+
+    /**
+     * Avoid odbc file open http://php.net/manual/en/function.odbc-execute.php
+     *
+     * @param array<mixed> $bind
+     * @return array<mixed>
+     */
+    private function repairBinding(array $bind): array
+    {
+        return array_map(function ($value) {
+            if (preg_match("/^'.*'$/", $value)) {
+                return " {$value} ";
+            }
+
+            return $value;
+        }, $bind);
+    }
+}

--- a/src/Table/Teradata/TeradataTableReflection.php
+++ b/src/Table/Teradata/TeradataTableReflection.php
@@ -156,7 +156,7 @@ final class TeradataTableReflection implements TableReflectionInterface
     {
         $sql = sprintf(
             "
-        SELECT ColumnName FROM DBC.IndicesV WHERE
+        SELECT ColumnName FROM DBC.IndicesVX WHERE
          IndexType = 'K'
          AND DatabaseName = %s 
          AND TableName = %s ORDER BY ColumnName;",
@@ -172,7 +172,7 @@ final class TeradataTableReflection implements TableReflectionInterface
     {
         $sql = sprintf(
             '
-SELECT CURRENTPERM FROM DBC.ALLSPACE
+SELECT CURRENTPERM FROM DBC.AllSpaceVX
 WHERE  DATABASENAME = %s AND TABLENAME = %s 
 ',
             TeradataQuote::quote($this->dbName),

--- a/src/View/Teradata/TeradataViewReflection.php
+++ b/src/View/Teradata/TeradataViewReflection.php
@@ -50,6 +50,14 @@ class TeradataViewReflection implements ViewReflectionInterface
                 )
             );
 
+            var_export($this->connection->fetchAllAssociative(
+                sprintf(
+                    'SHOW VIEW %s.%s',
+                    TeradataQuote::quoteSingleIdentifier($this->databaseName),
+                    TeradataQuote::quoteSingleIdentifier(trim($view['TableName']))
+                )
+            ));
+
             // trim table name from teradata, returned with whitespaces
             $viewNameWithDatabase = sprintf(
                 '%s.%s',

--- a/src/View/Teradata/TeradataViewReflection.php
+++ b/src/View/Teradata/TeradataViewReflection.php
@@ -50,14 +50,6 @@ class TeradataViewReflection implements ViewReflectionInterface
                 )
             );
 
-            var_export($this->connection->fetchAllAssociative(
-                sprintf(
-                    'SHOW VIEW %s.%s',
-                    TeradataQuote::quoteSingleIdentifier($this->databaseName),
-                    TeradataQuote::quoteSingleIdentifier(trim($view['TableName']))
-                )
-            ));
-
             // trim table name from teradata, returned with whitespaces
             $viewNameWithDatabase = sprintf(
                 '%s.%s',

--- a/tests/Functional/Table/Teradata/TeradataTableReflectionTest.php
+++ b/tests/Functional/Table/Teradata/TeradataTableReflectionTest.php
@@ -139,7 +139,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CHAR WITH LENGTH' => [
             'CHAR (20)', // SQL to create column
-            'CHAR (20)', // expected SQL
+            'CHAR (20) CHARACTER SET LATIN', // expected SQL
             'CHAR', // type
             null, // default
             20, // length
@@ -279,7 +279,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'VARCHAR' => [
             'VARCHAR (32000)',
-            'VARCHAR (32000)',
+            'VARCHAR (32000) CHARACTER SET LATIN',
             'VARCHAR',
             null,
             32000,
@@ -287,7 +287,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'LONG VARCHAR' => [
             'VARCHAR (64000)',
-            'VARCHAR (64000)',
+            'VARCHAR (64000) CHARACTER SET LATIN',
             'VARCHAR',
             null,
             64000,
@@ -295,7 +295,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'LONG VARCHAR with UNICODE' => [
             'VARCHAR (32000) CHARACTER SET UNICODE',
-            'VARCHAR (32000)',
+            'VARCHAR (32000) CHARACTER SET UNICODE',
             'VARCHAR',
             null,
             32000,
@@ -303,7 +303,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CLOB' => [
             'CLOB (2M)',
-            'CLOB (2097152)',
+            'CLOB (2097152) CHARACTER SET LATIN',
             'CLOB',
             null,
             '2097152',
@@ -311,7 +311,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CLOB with Unicode' => [
             'CLOB (2M)  CHARACTER SET UNICODE',
-            'CLOB (2097152)',
+            'CLOB (2097152) CHARACTER SET UNICODE',
             'CLOB',
             null,
             '2097152',

--- a/tests/Functional/Table/Teradata/TeradataTableReflectionTest.php
+++ b/tests/Functional/Table/Teradata/TeradataTableReflectionTest.php
@@ -77,7 +77,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ?string $expectedNullable
     ): void {
         $sql = sprintf(
-            'CREATE MULTISET TABLE %s.%s ,NO FALLBACK ,
+            'CREATE MULTISET TABLE %s.%s ,
      NO BEFORE JOURNAL,
      NO AFTER JOURNAL,
      CHECKSUM = DEFAULT,
@@ -139,7 +139,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CHAR WITH LENGTH' => [
             'CHAR (20)', // SQL to create column
-            'CHAR (20) CHARACTER SET LATIN', // expected SQL
+            'CHAR (20)', // expected SQL
             'CHAR', // type
             null, // default
             20, // length
@@ -279,7 +279,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'VARCHAR' => [
             'VARCHAR (32000)',
-            'VARCHAR (32000) CHARACTER SET LATIN',
+            'VARCHAR (32000)',
             'VARCHAR',
             null,
             32000,
@@ -287,7 +287,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'LONG VARCHAR' => [
             'VARCHAR (64000)',
-            'VARCHAR (64000) CHARACTER SET LATIN',
+            'VARCHAR (64000)',
             'VARCHAR',
             null,
             64000,
@@ -295,7 +295,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'LONG VARCHAR with UNICODE' => [
             'VARCHAR (32000) CHARACTER SET UNICODE',
-            'VARCHAR (32000) CHARACTER SET UNICODE',
+            'VARCHAR (32000)',
             'VARCHAR',
             null,
             32000,
@@ -303,7 +303,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CLOB' => [
             'CLOB (2M)',
-            'CLOB (2097152) CHARACTER SET LATIN',
+            'CLOB (2097152)',
             'CLOB',
             null,
             '2097152',
@@ -311,7 +311,7 @@ class TeradataTableReflectionTest extends TeradataBaseCase
         ];
         yield 'CLOB with Unicode' => [
             'CLOB (2M)  CHARACTER SET UNICODE',
-            'CLOB (2097152) CHARACTER SET UNICODE',
+            'CLOB (2097152)',
             'CLOB',
             null,
             '2097152',

--- a/tests/Functional/Teradata/TeradataBaseCase.php
+++ b/tests/Functional/Teradata/TeradataBaseCase.php
@@ -40,11 +40,11 @@ class TeradataBaseCase extends TestCase
         // char because of Stats test
         $this->connection->executeQuery(
             sprintf(
-                'CREATE MULTISET TABLE %s.%s ,NO FALLBACK
+                'CREATE MULTISET TABLE %s.%s
      (
       "id" INTEGER NOT NULL,
-      "first_name" CHAR(10000),
-      "last_name" CHAR(10000)
+      "first_name" VARCHAR(10000),
+      "last_name" VARCHAR(10000)
      );',
                 TeradataQuote::quoteSingleIdentifier($database),
                 TeradataQuote::quoteSingleIdentifier($table)
@@ -98,11 +98,11 @@ CREATE DATABASE %s AS
         ]);
     }
 
-    public function testConnection(): void
+    public function assertConnectionIsWorking(Connection $connection): void
     {
         self::assertEquals(
             1,
-            $this->connection->fetchOne('SELECT 1')
+            $connection->fetchOne('SELECT 1')
         );
     }
 
@@ -210,5 +210,27 @@ CREATE DATABASE %s AS
 
         //shuffle the password string before returning!
         return str_shuffle($password);
+    }
+
+    /**
+     * @param array<int|string, mixed> $expected
+     * @param array<int|string, mixed> $actual
+     * @param int|string $sortKey
+     */
+    protected function assertArrayEqualsSorted(
+        array $expected,
+        array $actual,
+        $sortKey,
+        string $message = ''
+    ): void {
+        $comparison = function ($attrLeft, $attrRight) use ($sortKey) {
+            if ($attrLeft[$sortKey] === $attrRight[$sortKey]) {
+                return 0;
+            }
+            return $attrLeft[$sortKey] < $attrRight[$sortKey] ? -1 : 1;
+        };
+        usort($expected, $comparison);
+        usort($actual, $comparison);
+        $this->assertEqualsCanonicalizing($expected, $actual, $message);
     }
 }

--- a/tests/Functional/Teradata/TestConnectionTest.php
+++ b/tests/Functional/Teradata/TestConnectionTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\TableBackendUtils\Functional\Teradata;
 
-use Keboola\TableBackendUtils\Table\SynapseTableQueryBuilder;
+use Keboola\TableBackendUtils\Connection\Teradata\TeradataConnection;
+use Keboola\TableBackendUtils\Escaping\Teradata\TeradataQuote;
 
-/**
- * @covers SynapseTableQueryBuilder
- */
 class TestConnectionTest extends TeradataBaseCase
 {
     public const TEST_SCHEMA = self::TESTS_PREFIX . 'qb-schema';
@@ -21,11 +19,202 @@ class TestConnectionTest extends TeradataBaseCase
     protected function setUp(): void
     {
         parent::setUp();
+        $this->cleanDatabase($this->getDatabaseName());
+        $this->createDatabase($this->getDatabaseName());
+    }
+
+    public function testTeradataConnection(): void
+    {
+        $this->assertConnectionIsWorking($this->connection);
     }
 
     public function testGetDatabase(): void
     {
         $databaseName = $this->connection->executeQuery('SELECT DATABASE')->fetchOne();
         self::assertNotNull($databaseName);
+    }
+
+    public function testTeradataFetchAll(): void
+    {
+        $this->initTable();
+        $data = [
+            [1, 'franta', 'omacka'],
+            [2, 'pepik', 'knedla'],
+        ];
+        foreach ($data as $item) {
+            $this->insertRowToTable($this->getDatabaseName(), self::TABLE_GENERIC, ...$item);
+        }
+        $sqlSelect = sprintf(
+            'SELECT * FROM %s.%s',
+            TeradataQuote::quoteSingleIdentifier($this->getDatabaseName()),
+            TeradataQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
+        );
+        $sqlSelectBindNamed = sprintf(
+            'SELECT * FROM %s.%s WHERE "first_name" = :first_name',
+            TeradataQuote::quoteSingleIdentifier($this->getDatabaseName()),
+            TeradataQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
+        );
+        $sqlSelectBindMultipleNamed = sprintf(
+            'SELECT * FROM %s.%s WHERE "first_name" = :first_name AND "last_name" = :last_name ',
+            TeradataQuote::quoteSingleIdentifier($this->getDatabaseName()),
+            TeradataQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
+        );
+        $sqlSelectBindNotNamed = sprintf(
+            'SELECT * FROM %s.%s WHERE "first_name" = ?',
+            TeradataQuote::quoteSingleIdentifier($this->getDatabaseName()),
+            TeradataQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
+        );
+        $sqlSelectBindMultipleNotNamed = sprintf(
+            'SELECT * FROM %s.%s WHERE "first_name" = ? AND "last_name" = ?',
+            TeradataQuote::quoteSingleIdentifier($this->getDatabaseName()),
+            TeradataQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
+        );
+
+        $result = $this->connection->fetchAllAssociative($sqlSelect);
+        $this->assertArrayEqualsSorted(
+            [
+                [
+                    'id' => '1',
+                    'first_name' => 'franta',
+                    'last_name' => 'omacka',
+                ],
+                [
+                    'id' => '2',
+                    'first_name' => 'pepik',
+                    'last_name' => 'knedla',
+                ],
+            ],
+            $result,
+            'id'
+        );
+
+        $result = $this->connection->fetchAllAssociative($sqlSelectBindNamed, ['first_name' => 'franta']);
+        $this->assertSame([
+            [
+                'id' => '1',
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchAllAssociative($sqlSelectBindMultipleNamed, [
+            'first_name' => 'franta',
+            'last_name' => 'omacka',
+        ]);
+        $this->assertSame([
+            [
+                'id' => '1',
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchAllAssociative($sqlSelectBindNotNamed, ['franta']);
+        $this->assertSame([
+            [
+                'id' => '1',
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchAllAssociative($sqlSelectBindMultipleNotNamed, ['franta', 'omacka']);
+        $this->assertSame([
+            [
+                'id' => '1',
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchAllAssociativeIndexed($sqlSelect);
+        ksort($result);
+        $this->assertSame([
+            1 => [
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+            2 => [
+                'first_name' => 'pepik',
+                'last_name' => 'knedla',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchAllAssociativeIndexed($sqlSelectBindNamed, ['first_name' => 'franta']);
+        $this->assertSame([
+            1 => [
+                'first_name' => 'franta',
+                'last_name' => 'omacka',
+            ],
+        ], $result);
+
+        $result = $this->connection->fetchFirstColumn($sqlSelect);
+        sort($result);
+        $this->assertSame([
+            '1',
+            '2',
+        ], $result);
+
+        $result = $this->connection->fetchFirstColumn($sqlSelectBindNamed, ['first_name' => 'franta']);
+        $this->assertSame([
+            '1',
+        ], $result);
+
+        $result = $this->connection->fetchAssociative($sqlSelectBindNamed, ['first_name' => 'pepik']);
+        $this->assertSame([
+            'id' => '2',
+            'first_name' => 'pepik',
+            'last_name' => 'knedla',
+
+        ], $result);
+
+        $result = $this->connection->fetchAllKeyValue($sqlSelect);
+        ksort($result);
+        $this->assertSame([
+            1 => 'franta',
+            2 => 'pepik',
+        ], $result);
+
+        $result = $this->connection->fetchAllKeyValue($sqlSelectBindNamed, ['first_name' => 'franta']);
+        $this->assertSame([
+            1 => 'franta',
+        ], $result);
+
+        $result = $this->connection->fetchAllNumeric($sqlSelectBindNamed, ['first_name' => 'franta']);
+        $this->assertSame([
+            [
+                '1',
+                'franta',
+                'omacka',
+            ],
+        ], $result);
+    }
+
+    public function testWillDisconnect(): void
+    {
+        $wrappedConnection = TeradataConnection::getConnection([
+            'host' => (string) getenv('TERADATA_HOST'),
+            'user' => (string) getenv('TERADATA_USERNAME'),
+            'password' => (string) getenv('TERADATA_PASSWORD'),
+            'port' => (int) getenv('TERADATA_PORT'),
+            'dbname' => '',
+        ]);
+        $wrappedConnectionRef = new \ReflectionClass($wrappedConnection);
+        $wrappedConnectionPropRef = $wrappedConnectionRef->getProperty('_conn');
+        $wrappedConnectionPropRef->setAccessible(true);
+        $wrappedConnection->connect(); // create odbc resource
+        $teradataConnection = $wrappedConnectionPropRef->getValue($wrappedConnection);
+        $teradataConnectionPropRef = new \ReflectionClass($teradataConnection);
+        $teradataConnectionPropRef = $teradataConnectionPropRef->getProperty('conn');
+        $teradataConnectionPropRef->setAccessible(true);
+        // check resource exists
+        $this->assertIsResource($teradataConnectionPropRef->getValue($teradataConnection));
+        $this->assertSame('odbc link', get_resource_type($teradataConnectionPropRef->getValue($teradataConnection)));
+        $wrappedConnection->close();
+
+        $this->assertNull($wrappedConnectionPropRef->getValue($wrappedConnection));
+        // try reconnect
+        $this->assertConnectionIsWorking($wrappedConnection);
+        $wrappedConnection->close();
     }
 }

--- a/tests/Functional/Teradata/TestConnectionTest.php
+++ b/tests/Functional/Teradata/TestConnectionTest.php
@@ -199,13 +199,21 @@ class TestConnectionTest extends TeradataBaseCase
             'port' => (int) getenv('TERADATA_PORT'),
             'dbname' => '',
         ]);
+        $wrappedConnection->connect(); // create odbc resource
+
+        // get retry wrapper
         $wrappedConnectionRef = new \ReflectionClass($wrappedConnection);
         $wrappedConnectionPropRef = $wrappedConnectionRef->getProperty('_conn');
         $wrappedConnectionPropRef->setAccessible(true);
-        $wrappedConnection->connect(); // create odbc resource
-        $teradataConnection = $wrappedConnectionPropRef->getValue($wrappedConnection);
-        $teradataConnectionPropRef = new \ReflectionClass($teradataConnection);
-        $teradataConnectionPropRef = $teradataConnectionPropRef->getProperty('conn');
+        $retryWrappedConnection = $wrappedConnectionPropRef->getValue($wrappedConnection);
+        // now get teradata connection from retry wrapper
+        $retryWrappedConnectionRef = new \ReflectionClass($retryWrappedConnection);
+        $retryWrappedConnectionPropRef = $retryWrappedConnectionRef->getProperty('connection');
+        $retryWrappedConnectionPropRef->setAccessible(true);
+        $teradataConnection = $retryWrappedConnectionPropRef->getValue($retryWrappedConnection);
+        // now get odbc connection
+        $teradataConnectionRef = new \ReflectionClass($teradataConnection);
+        $teradataConnectionPropRef = $teradataConnectionRef->getProperty('conn');
         $teradataConnectionPropRef->setAccessible(true);
         // check resource exists
         $this->assertIsResource($teradataConnectionPropRef->getValue($teradataConnection));


### PR DESCRIPTION
PDO doesn't work with Teradata ODBC driver, this is mostly copy paster from SNFLK to make it work, would be great to refactor this later, and make generic ODBC driver maybe.
There is also some small fixes:
- DBC views are now VX older views have limit for object names
- more patterns for retry on TD
- removed debug statement

---
kind of weird are CHARACTER SET value on columns, it was not part of HELP and than tests did fail as it was there. It's super confusing.