### PR TITLE
Add UTF8 encoding to exasol dsn

### DIFF
--- a/src/Connection/Exasol/ExasolDriver.php
+++ b/src/Connection/Exasol/ExasolDriver.php
@@ -26,7 +26,7 @@ class ExasolDriver implements Driver
         assert(array_key_exists('host', $params));
         assert(array_key_exists('user', $params));
         assert(array_key_exists('password', $params));
-        $dsn = 'odbc:Driver=exasol;EXAHOST=' . $params['host'];
+        $dsn = 'odbc:Driver=exasol;ENCODING=UTF-8;EXAHOST=' . $params['host'];
 
         if ($params['skipCertCheck']) {
             $dsn .= ';FINGERPRINT=NoCertCheck;';


### PR DESCRIPTION
there was missing encoding param after Exasol driver refactoring https://github.com/keboola/php-table-backend-utils/pull/41/files#diff-39938b58877087b59c064eea5fff0284ec7638984e92fe33a3828f60848a5449R28