### PR TITLE
Snflk creates temp tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
     },
     "config": {
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/Table/Snowflake/SnowflakeTableQueryBuilder.php
+++ b/src/Table/Snowflake/SnowflakeTableQueryBuilder.php
@@ -159,6 +159,14 @@ class SnowflakeTableQueryBuilder implements TableQueryBuilderInterface
         bool $definePrimaryKeys = self::CREATE_TABLE_WITHOUT_PRIMARY_KEYS
     ): string {
         assert($definition instanceof SnowflakeTableDefinition);
+        if ($definition->isTemporary()) {
+            return $this->getCreateTempTableCommand(
+                $definition->getSchemaName(),
+                $definition->getTableName(),
+                $definition->getColumnsDefinitions()
+            );
+        }
+
         return $this->getCreateTableCommand(
             $definition->getSchemaName(),
             $definition->getTableName(),

--- a/tests/Functional/Snowflake/Table/SnowflakeTableQueryBuilderTest.php
+++ b/tests/Functional/Snowflake/Table/SnowflakeTableQueryBuilderTest.php
@@ -333,6 +333,52 @@ EOT
             ,
             'createPrimaryKeys' => false,
         ];
+        yield 'temporary table' => [
+            'definition' => new SnowflakeTableDefinition(
+                $testDb,
+                '__temp_' . $tableName,
+                true,
+                new ColumnCollection(
+                    [
+                        SnowflakeColumn::createGenericColumn('col1'),
+                        SnowflakeColumn::createGenericColumn('col2'),
+                    ]
+                ),
+                []
+            ),
+            'query' => <<<EOT
+CREATE TEMPORARY TABLE "$testDb"."__temp_$tableName"
+(
+"col1" VARCHAR NOT NULL,
+"col2" VARCHAR NOT NULL
+);
+EOT
+            ,
+            'createPrimaryKeys' => false,
+        ];
+        yield 'temporary table with pk' => [
+            'definition' => new SnowflakeTableDefinition(
+                $testDb,
+                '__temp_' . $tableName,
+                true,
+                new ColumnCollection(
+                    [
+                        SnowflakeColumn::createGenericColumn('col1'),
+                        SnowflakeColumn::createGenericColumn('col2'),
+                    ]
+                ),
+                ['col1', 'col2']
+            ),
+            'query' => <<<EOT
+CREATE TEMPORARY TABLE "$testDb"."__temp_$tableName"
+(
+"col1" VARCHAR NOT NULL,
+"col2" VARCHAR NOT NULL
+);
+EOT
+            ,
+            'createPrimaryKeys' => false,
+        ];
     }
 
     /**
@@ -350,7 +396,12 @@ EOT
         $this->connection->executeQuery($sql);
 
         // test table properties
-        $tableReflection = new SnowflakeTableReflection($this->connection, self::TEST_SCHEMA, self::TABLE_GENERIC);
+        $tableReflection = new SnowflakeTableReflection(
+            $this->connection,
+            self::TEST_SCHEMA,
+            $definition->getTableName()
+        );
+
         self::assertSame($definition->getColumnsNames(), $tableReflection->getColumnsNames());
         if ($createPrimaryKeys) {
             self::assertSame($definition->getPrimaryKeysNames(), $tableReflection->getPrimaryKeysNames());


### PR DESCRIPTION
Snflk creates temp tables if the definition is temp=true

used in https://github.com/keboola/php-db-import-export/pull/116