### PR TITLE
Align table name validation with connection

### DIFF
--- a/src/Table/Snowflake/SnowflakeTableQueryBuilder.php
+++ b/src/Table/Snowflake/SnowflakeTableQueryBuilder.php
@@ -196,10 +196,21 @@ class SnowflakeTableQueryBuilder implements TableQueryBuilderInterface
 
     private function assertTableName(string $tableName): void
     {
-        if (preg_match('/^[_A-Za-z][_A-Za-z0-9$]*$/', $tableName, $out) !== 1) {
+        if (preg_match('/^[-_A-Za-z][_A-Za-z\d$]*$/', $tableName, $out) !== 1) {
             throw new QueryBuilderException(
                 sprintf(
-                    'Invalid table name %s: Only alphanumeric characters, underscores and dollar signs are allowed.',
+                    // phpcs:ignore
+                    'Invalid table name %s: Only alphanumeric characters, dash, underscores and dollar signs are allowed.',
+                    $tableName
+                ),
+                self::INVALID_TABLE_NAME
+            );
+        }
+
+        if (ctype_print($tableName) === false) {
+            throw new QueryBuilderException(
+                sprintf(
+                    'Invalid table name %s: Name can contain only printable characters.',
                     $tableName
                 ),
                 self::INVALID_TABLE_NAME

--- a/src/Table/SynapseTableReflection.php
+++ b/src/Table/SynapseTableReflection.php
@@ -359,7 +359,7 @@ EOT
     public function getTableIndexColumnsNames(): array
     {
         $tableId = $this->getObjectId();
-        /** @var array{0?: string} $result */
+        /** @var string[] $result */
         $result = $this->connection->fetchFirstColumn(
             <<< EOT
 SELECT

--- a/tests/Functional/Snowflake/Table/SnowflakeTableReflectionTest.php
+++ b/tests/Functional/Snowflake/Table/SnowflakeTableReflectionTest.php
@@ -151,7 +151,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
     {
         yield 'DECIMAL' => [
             'DECIMAL', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -159,7 +159,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'NUMERIC' => [
             'NUMERIC', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -167,7 +167,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'NUMERIC 20' => [
             'NUMERIC (20,0)', // sql which goes to table
-            'NUMBER(20,0)', // expected sql from getSQLDefinition
+            'NUMBER (20,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '20,0', // length
@@ -175,7 +175,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'INT' => [
             'INT', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -183,7 +183,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'INTEGER' => [
             'INTEGER', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -191,7 +191,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'BIGINT' => [
             'BIGINT', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -199,7 +199,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'SMALLINT' => [
             'SMALLINT', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -207,7 +207,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'TINYINT' => [
             'TINYINT', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -215,7 +215,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'BYTEINT' => [
             'BYTEINT', // sql which goes to table
-            'NUMBER(38,0)', // expected sql from getSQLDefinition
+            'NUMBER (38,0)', // expected sql from getSQLDefinition
             'NUMBER', // expected type from db
             null, // default
             '38,0', // length
@@ -271,7 +271,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'VARCHAR' => [
             'VARCHAR', // sql which goes to table
-            'VARCHAR(16777216)', // expected sql from getSQLDefinition
+            'VARCHAR (16777216)', // expected sql from getSQLDefinition
             'VARCHAR', // expected type from db
             null, // default
             '16777216', // length
@@ -279,7 +279,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'CHAR' => [
             'CHAR', // sql which goes to table
-            'VARCHAR(1)', // expected sql from getSQLDefinition
+            'VARCHAR (1)', // expected sql from getSQLDefinition
             'VARCHAR', // expected type from db
             null, // default
             '1', // length
@@ -287,7 +287,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'CHARACTER' => [
             'CHARACTER', // sql which goes to table
-            'VARCHAR(1)', // expected sql from getSQLDefinition
+            'VARCHAR (1)', // expected sql from getSQLDefinition
             'VARCHAR', // expected type from db
             null, // default
             '1', // length
@@ -295,7 +295,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'STRING' => [
             'STRING', // sql which goes to table
-            'VARCHAR(16777216)', // expected sql from getSQLDefinition
+            'VARCHAR (16777216)', // expected sql from getSQLDefinition
             'VARCHAR', // expected type from db
             null, // default
             '16777216', // length
@@ -303,7 +303,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'TEXT' => [
             'TEXT', // sql which goes to table
-            'VARCHAR(16777216)', // expected sql from getSQLDefinition
+            'VARCHAR (16777216)', // expected sql from getSQLDefinition
             'VARCHAR', // expected type from db
             null, // default
             '16777216', // length
@@ -327,7 +327,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'DATETIME' => [
             'DATETIME', // sql which goes to table
-            'TIMESTAMP_NTZ(9)', // expected sql from getSQLDefinition
+            'TIMESTAMP_NTZ (9)', // expected sql from getSQLDefinition
             'TIMESTAMP_NTZ', // expected type from db
             null, // default
             '9', // length
@@ -335,7 +335,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'TIME' => [
             'TIME', // sql which goes to table
-            'TIME(9)', // expected sql from getSQLDefinition
+            'TIME (9)', // expected sql from getSQLDefinition
             'TIME', // expected type from db
             null, // default
             '9', // length
@@ -343,7 +343,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'TIMESTAMP' => [
             'TIMESTAMP', // sql which goes to table
-            'TIMESTAMP_NTZ(9)', // expected sql from getSQLDefinition
+            'TIMESTAMP_NTZ (9)', // expected sql from getSQLDefinition
             'TIMESTAMP_NTZ', // expected type from db
             null, // default
             '9', // length
@@ -359,7 +359,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'BINARY' => [
             'BINARY', // sql which goes to table
-            'BINARY(8388608)', // expected sql from getSQLDefinition
+            'BINARY (8388608)', // expected sql from getSQLDefinition
             'BINARY', // expected type from db
             null, // default
             '8388608', // length
@@ -367,7 +367,7 @@ class SnowflakeTableReflectionTest extends SnowflakeBaseCase
         ];
         yield 'VARBINARY' => [
             'VARBINARY', // sql which goes to table
-            'BINARY(8388608)', // expected sql from getSQLDefinition
+            'BINARY (8388608)', // expected sql from getSQLDefinition
             'BINARY', // expected type from db
             null, // default
             '8388608', // length

--- a/tests/Unit/Column/Snowflake/SnowflakeColumnTest.php
+++ b/tests/Unit/Column/Snowflake/SnowflakeColumnTest.php
@@ -40,7 +40,7 @@ class SnowflakeColumnTest extends TestCase
 
         $column = SnowflakeColumn::createFromDB($data);
         self::assertEquals('first_name', $column->getColumnName());
-        self::assertEquals('VARCHAR(16777216)', $column->getColumnDefinition()->getSQLDefinition());
+        self::assertEquals('VARCHAR (16777216)', $column->getColumnDefinition()->getSQLDefinition());
         self::assertEquals('VARCHAR', $column->getColumnDefinition()->getType());
         self::assertEquals('', $column->getColumnDefinition()->getDefault());
         self::assertEquals('16777216', $column->getColumnDefinition()->getLength());
@@ -65,7 +65,7 @@ class SnowflakeColumnTest extends TestCase
 
         $column = SnowflakeColumn::createFromDB($data);
         self::assertEquals('age', $column->getColumnName());
-        self::assertEquals('NUMBER(38,0) NOT NULL', $column->getColumnDefinition()->getSQLDefinition());
+        self::assertEquals('NUMBER (38,0) NOT NULL', $column->getColumnDefinition()->getSQLDefinition());
         self::assertEquals('NUMBER', $column->getColumnDefinition()->getType());
         self::assertEquals('18', $column->getColumnDefinition()->getDefault());
         self::assertEquals('38,0', $column->getColumnDefinition()->getLength());

--- a/tests/Unit/Table/Snowflake/SnowflakeTableQueryBuilderTest.php
+++ b/tests/Unit/Table/Snowflake/SnowflakeTableQueryBuilderTest.php
@@ -65,9 +65,9 @@ class SnowflakeTableQueryBuilderTest extends TestCase
     {
         $this->expectException(QueryBuilderException::class);
         $this->expectExceptionMessage(
-            'Invalid table name testTable.: Only alphanumeric characters, underscores and dollar signs are allowed.'
+            'Invalid table name testTab.: Only alphanumeric characters, dash, underscores and dollar signs are allowed.'
         );
-        $this->qb->getCreateTableCommand('testDb', 'testTable.', new ColumnCollection([]));
+        $this->qb->getCreateTableCommand('testDb', 'testTab.', new ColumnCollection([]));
         self::fail('Should fail because of invalid table name');
     }
 
@@ -75,9 +75,9 @@ class SnowflakeTableQueryBuilderTest extends TestCase
     {
         $this->expectException(QueryBuilderException::class);
         $this->expectExceptionMessage(
-            'Invalid table name testTable.: Only alphanumeric characters, underscores and dollar signs are allowed.'
+            'Invalid table name testTab.: Only alphanumeric characters, dash, underscores and dollar signs are allowed.'
         );
-        $this->qb->getRenameTableCommand('testDb', 'testTable', 'testTable.');
+        $this->qb->getRenameTableCommand('testDb', 'testTab', 'testTab.');
         self::fail('Should fail because of invalid table name');
     }
 


### PR DESCRIPTION
It should be compatible with https://github.com/keboola/connection/blob/master/legacy-app/library/Keboola/Validate/Mysql/DatabaseSafeNameValidate.php 

Zblaznil se mi pak phpstan a testy bo se tam povysily datatypes, tak jsem to vsechno pofixoval