### PR TITLE
KBC-2809 snflk limit of columns

### DIFF
--- a/src/Column/ColumnCollection.php
+++ b/src/Column/ColumnCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\TableBackendUtils\Column;
 
 use Keboola\Datatype\Definition\Redshift;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\Datatype\Definition\Synapse;
 use Keboola\Datatype\Definition\Teradata;
 use Keboola\TableBackendUtils\Collection;
@@ -23,6 +24,8 @@ final class ColumnCollection extends Collection
         // https://docs.teradata.com/r/Teradata-VantageTM-Database-Design/March-2019/Teradata-System-Limits/Database-Limits
         Redshift::class => 1600,
         // https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_usage.html
+        Snowflake::class => 1201,
+        // limit is 16MB -> manual limit to 1200 + timestamp
     ];
 
     /**
@@ -47,7 +50,8 @@ final class ColumnCollection extends Collection
                 $limit = self::$limits[$firstDefinitionClass];
                 if (count($columns) > $limit) {
                     throw new ColumnException(
-                        sprintf('Too many columns. Maximum is %s columns.', $limit),
+                        // we have to force user to create MAX-1 columns, becase we need 1 for timestamp
+                        sprintf('Too many columns. Maximum is %s columns.', $limit - 1),
                         ColumnException::STRING_CODE_TO_MANY_COLUMNS
                     );
                 }

--- a/tests/Unit/Column/ColumnCollectionTest.php
+++ b/tests/Unit/Column/ColumnCollectionTest.php
@@ -37,7 +37,7 @@ class ColumnCollectionTest extends TestCase
         }
 
         $this->expectException(ColumnException::class);
-        $this->expectExceptionMessage(sprintf('Too many columns. Maximum is %s columns.', $limit));
+        $this->expectExceptionMessage(sprintf('Too many columns. Maximum is %s columns.', $limit - 1));
         new ColumnCollection($cols);
     }
 
@@ -80,6 +80,10 @@ class ColumnCollectionTest extends TestCase
                     TeradataColumn::class,
                     2048,
                 ],
+                'snowflake' => [
+                    SnowflakeColumn::class,
+                    1201,
+                ],
             ];
     }
 
@@ -90,10 +94,6 @@ class ColumnCollectionTest extends TestCase
     {
         return
             [
-                'snowflake' => [
-                    SnowflakeColumn::class,
-                    5000,
-                ],
                 'exasol' => [
                     ExasolColumn::class,
                     5000,


### PR DESCRIPTION
https://github.com/keboola/connection/pull/3877 limit na pocet sloupcu presunuty sem. limit je 1201 protoze slibujeme  (minimalne to je v SAPI testu) 1200 a tak ten limit (kterej je ale soft) musi byt nastaveny na 1201.

Ostatni backendy bohuzel budou ukazovat trochu divna cisla (1023 nebo 2047), ale musi to tak byt, protoze tyto limity jsou hard a my tam strkame jeste timestamp, takze pokud to ma zvalidovat "tato collection pujde vytvorit", tak uzivateli musime prezentovat cislo o 1 mensi