### PR TITLE
KBC-2903 Synapse uppercase

### DIFF
--- a/src/Column/SynapseColumn.php
+++ b/src/Column/SynapseColumn.php
@@ -6,6 +6,7 @@ namespace Keboola\TableBackendUtils\Column;
 
 use Keboola\Datatype\Definition\DefinitionInterface;
 use Keboola\Datatype\Definition\Synapse;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 final class SynapseColumn implements ColumnInterface
 {
@@ -15,7 +16,7 @@ final class SynapseColumn implements ColumnInterface
 
     public function __construct(string $columnName, Synapse $columnDefinition)
     {
-        $this->columnName = $columnName;
+        $this->columnName = CaseConverter::stringToUpper($columnName);
         $this->columnDefinition = $columnDefinition;
     }
 

--- a/src/Schema/SynapseSchemaQueryBuilder.php
+++ b/src/Schema/SynapseSchemaQueryBuilder.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Keboola\TableBackendUtils\Schema;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 class SynapseSchemaQueryBuilder
 {
     public function getCreateSchemaCommand(string $schemaName): string
     {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
         return sprintf('CREATE SCHEMA %s', SynapseQuote::quoteSingleIdentifier($schemaName));
     }
 
     public function getDropSchemaCommand(string $schemaName): string
     {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
         return sprintf('DROP SCHEMA %s', SynapseQuote::quoteSingleIdentifier($schemaName));
     }
 }

--- a/src/Schema/SynapseSchemaReflection.php
+++ b/src/Schema/SynapseSchemaReflection.php
@@ -6,6 +6,7 @@ namespace Keboola\TableBackendUtils\Schema;
 
 use Doctrine\DBAL\Connection;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 final class SynapseSchemaReflection implements SchemaReflectionInterface
 {
@@ -35,7 +36,7 @@ order by name;
 EOT
         );
 
-        return array_map(static fn($table) => $table['name'], $tables);
+        return array_map(static fn($table) => CaseConverter::stringToUpper($table['name']), $tables);
     }
 
     /**
@@ -54,6 +55,6 @@ order by name;
 EOT
         );
 
-        return array_map(static fn($table) => $table['name'], $tables);
+        return array_map(static fn($table) => CaseConverter::stringToUpper($table['name']), $tables);
     }
 }

--- a/src/Table/Synapse/TableDistributionDefinition.php
+++ b/src/Table/Synapse/TableDistributionDefinition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\TableBackendUtils\Table\Synapse;
 
+use Keboola\TableBackendUtils\Utils\CaseConverter;
+
 final class TableDistributionDefinition
 {
     public const TABLE_DISTRIBUTION_HASH = 'HASH';
@@ -33,7 +35,7 @@ final class TableDistributionDefinition
         Assert::assertValidHashDistribution($distributionName, $distributionColumnsNames);
 
         $this->distributionName = $distributionName;
-        $this->distributionColumnsNames = $distributionColumnsNames;
+        $this->distributionColumnsNames = CaseConverter::arrayToUpper($distributionColumnsNames);
     }
 
     /**

--- a/src/Table/Synapse/TableIndexDefinition.php
+++ b/src/Table/Synapse/TableIndexDefinition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\TableBackendUtils\Table\Synapse;
 
+use Keboola\TableBackendUtils\Utils\CaseConverter;
+
 final class TableIndexDefinition
 {
     public const TABLE_INDEX_TYPE_CLUSTERED_COLUMNSTORE_INDEX = 'CLUSTERED COLUMNSTORE INDEX';
@@ -34,7 +36,7 @@ final class TableIndexDefinition
         Assert::assertValidClusteredIndex($indexType, $indexedColumnsNames);
 
         $this->indexType = $indexType;
-        $this->indexedColumnsNames = $indexedColumnsNames;
+        $this->indexedColumnsNames = CaseConverter::arrayToUpper($indexedColumnsNames);
     }
 
     /**

--- a/src/Table/SynapseTableDefinition.php
+++ b/src/Table/SynapseTableDefinition.php
@@ -8,6 +8,7 @@ use Keboola\TableBackendUtils\Column\ColumnCollection;
 use Keboola\TableBackendUtils\Column\ColumnInterface;
 use Keboola\TableBackendUtils\Table\Synapse\TableDistributionDefinition;
 use Keboola\TableBackendUtils\Table\Synapse\TableIndexDefinition;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 final class SynapseTableDefinition implements TableDefinitionInterface
 {
@@ -38,10 +39,10 @@ final class SynapseTableDefinition implements TableDefinitionInterface
         TableDistributionDefinition $tableDistribution,
         TableIndexDefinition $tableIndex
     ) {
-        $this->schemaName = $schemaName;
-        $this->tableName = $tableName;
+        $this->schemaName = CaseConverter::stringToUpper($schemaName);
+        $this->tableName = CaseConverter::stringToUpper($tableName);
         $this->columns = $columns;
-        $this->primaryKeysNames = $primaryKeysNames;
+        $this->primaryKeysNames = CaseConverter::arrayToUpper($primaryKeysNames);
         $this->tableDistribution = $tableDistribution;
         $this->isTemporary = $isTemporary;
         $this->tableIndex = $tableIndex;

--- a/src/Table/SynapseTableQueryBuilder.php
+++ b/src/Table/SynapseTableQueryBuilder.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\TableBackendUtils\Table;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Keboola\TableBackendUtils\Column\ColumnCollection;
 use Keboola\TableBackendUtils\Column\ColumnInterface;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
@@ -23,6 +20,8 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         ColumnCollection $columns
     ): string {
         $this->assertTemporaryTable($tableName);
+        $schemaName = CaseConverter::stringToUpper($schemaName);
+        $tableName = CaseConverter::stringToUpper($tableName);
 
         $columnsSql = [];
         foreach ($columns as $column) {
@@ -64,6 +63,8 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         ColumnCollection $columns,
         array $primaryKeys = []
     ): string {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
+        $tableName = CaseConverter::stringToUpper($tableName);
         $primaryKeys = CaseConverter::arrayToUpper($primaryKeys);
         $columnsSql = [];
         foreach ($columns as $column) {
@@ -174,6 +175,8 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         string $schemaName,
         string $tableName
     ): string {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
+        $tableName = CaseConverter::stringToUpper($tableName);
         return sprintf(
             'DROP TABLE %s.%s',
             SynapseQuote::quoteSingleIdentifier($schemaName),
@@ -186,6 +189,9 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         string $sourceTableName,
         string $newTableName
     ): string {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
+        $sourceTableName = CaseConverter::stringToUpper($sourceTableName);
+        $newTableName = CaseConverter::stringToUpper($newTableName);
         return sprintf(
             'RENAME OBJECT %s.%s TO %s',
             SynapseQuote::quoteSingleIdentifier($schemaName),
@@ -198,6 +204,8 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         string $schemaName,
         string $tableName
     ): string {
+        $schemaName = CaseConverter::stringToUpper($schemaName);
+        $tableName = CaseConverter::stringToUpper($tableName);
         return sprintf(
             'TRUNCATE TABLE %s.%s',
             SynapseQuote::quoteSingleIdentifier($schemaName),

--- a/src/Table/SynapseTableQueryBuilder.php
+++ b/src/Table/SynapseTableQueryBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\TableBackendUtils\Table;
 
+use Keboola\Datatype\Definition\Synapse;
 use Keboola\TableBackendUtils\Column\ColumnCollection;
 use Keboola\TableBackendUtils\Column\ColumnInterface;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
@@ -67,9 +68,10 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         $tableName = CaseConverter::stringToUpper($tableName);
         $primaryKeys = CaseConverter::arrayToUpper($primaryKeys);
         $columnsSql = [];
+        $timestampColumnUpper = CaseConverter::stringToUpper(ColumnInterface::TIMESTAMP_COLUMN_NAME);
         foreach ($columns as $column) {
-            if ($column->getColumnName() === ColumnInterface::TIMESTAMP_COLUMN_NAME) {
-                $columnsSql[] = sprintf('[%s] DATETIME2', ColumnInterface::TIMESTAMP_COLUMN_NAME);
+            if ($column->getColumnName() === $timestampColumnUpper) {
+                $columnsSql[] = sprintf('[%s] %s', $timestampColumnUpper, Synapse::TYPE_DATETIME2);
                 continue;
             }
             $columnsSql[] = sprintf(

--- a/src/Table/SynapseTableQueryBuilder.php
+++ b/src/Table/SynapseTableQueryBuilder.php
@@ -12,6 +12,7 @@ use Keboola\TableBackendUtils\Column\ColumnInterface;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
 use Keboola\TableBackendUtils\QueryBuilderException;
 use Keboola\TableBackendUtils\Table\Synapse\TableIndexDefinition;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 class SynapseTableQueryBuilder implements TableQueryBuilderInterface
 {
@@ -63,6 +64,7 @@ class SynapseTableQueryBuilder implements TableQueryBuilderInterface
         ColumnCollection $columns,
         array $primaryKeys = []
     ): string {
+        $primaryKeys = CaseConverter::arrayToUpper($primaryKeys);
         $columnsSql = [];
         foreach ($columns as $column) {
             if ($column->getColumnName() === ColumnInterface::TIMESTAMP_COLUMN_NAME) {

--- a/src/Table/SynapseTableReflection.php
+++ b/src/Table/SynapseTableReflection.php
@@ -12,6 +12,7 @@ use Keboola\TableBackendUtils\ReflectionException;
 use Keboola\TableBackendUtils\Table\Synapse\TableDistributionDefinition;
 use Keboola\TableBackendUtils\Table\Synapse\TableIndexDefinition;
 use Keboola\TableBackendUtils\TableNotExistsReflectionException;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 use LogicException;
 use function Keboola\Utils\returnBytes;
 
@@ -31,8 +32,8 @@ final class SynapseTableReflection implements TableReflectionInterface
     {
         // temporary tables starts with #
         $this->isTemporary = strpos($tableName, '#') === 0;
-        $this->tableName = $tableName;
-        $this->schemaName = $schemaName;
+        $this->tableName = CaseConverter::stringToUpper($tableName);
+        $this->schemaName = CaseConverter::stringToUpper($schemaName);
         $this->connection = $connection;
     }
 
@@ -52,7 +53,7 @@ final class SynapseTableReflection implements TableReflectionInterface
             SynapseQuote::quote($tableId)
         ));
 
-        return array_map(static fn($column) => $column['name'], $columns);
+        return array_map(static fn($column) => CaseConverter::stringToUpper($column['name']), $columns);
     }
 
     /**
@@ -175,7 +176,7 @@ SELECT COL_NAME(ic.OBJECT_ID,ic.column_id) AS column_name
 EOT
         );
 
-        return array_map(static fn($item) => $item['column_name'], $result);
+        return array_map(static fn($item) => CaseConverter::stringToUpper($item['column_name']), $result);
     }
 
     public function getTableStats(): TableStatsInterface
@@ -241,14 +242,14 @@ EOT
         $dependencies = [];
         foreach ($views as $view) {
             if ($view['VIEW_DEFINITION'] === null
-                || strpos($view['VIEW_DEFINITION'], $objectNameWithSchema) === false
+                || strpos(CaseConverter::stringToUpper($view['VIEW_DEFINITION']), $objectNameWithSchema) === false
             ) {
                 continue;
             }
 
             $dependencies[] = [
-                'schema_name' => $view['TABLE_SCHEMA'],
-                'name' => $view['TABLE_NAME'],
+                'schema_name' => CaseConverter::stringToUpper($view['TABLE_SCHEMA']),
+                'name' => CaseConverter::stringToUpper($view['TABLE_NAME']),
             ];
         }
 
@@ -290,7 +291,7 @@ WHERE dp.distribution_ordinal = 1 AND dp.OBJECT_ID = '$tableId' AND c.object_id 
 EOT
         );
 
-        return array_map(static fn($item) => $item['name'], $result);
+        return array_map(static fn($item) => CaseConverter::stringToUpper($item['name']), $result);
     }
 
     /**
@@ -389,6 +390,6 @@ EOT
             return [];
         }
 
-        return $result;
+        return CaseConverter::arrayToUpper($result);
     }
 }

--- a/src/Utils/CaseConverter.php
+++ b/src/Utils/CaseConverter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\TableBackendUtils\Utils;
+
+final class CaseConverter
+{
+    public static function stringToUpper(string $string): string
+    {
+        return strtoupper($string);
+    }
+
+    /**
+     * @param string[] $arr
+     * @return string[]
+     */
+    public static function arrayToUpper(array $arr): array
+    {
+        return array_map(static fn(string $string) => strtoupper($string), $arr);
+    }
+}

--- a/src/View/SynapseViewReflection.php
+++ b/src/View/SynapseViewReflection.php
@@ -7,6 +7,7 @@ namespace Keboola\TableBackendUtils\View;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Keboola\TableBackendUtils\Escaping\SynapseQuote;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 
 final class SynapseViewReflection implements ViewReflectionInterface
 {
@@ -53,8 +54,8 @@ final class SynapseViewReflection implements ViewReflectionInterface
             }
 
             $dependencies[] = [
-                'schema_name' => $view['TABLE_SCHEMA'],
-                'name' => $view['TABLE_NAME'],
+                'schema_name' => CaseConverter::stringToUpper($view['TABLE_SCHEMA']),
+                'name' => CaseConverter::stringToUpper($view['TABLE_NAME']),
             ];
         }
 

--- a/tests/Functional/Synapse/Schema/SynapseSchemaQueryBuilderTest.php
+++ b/tests/Functional/Synapse/Schema/SynapseSchemaQueryBuilderTest.php
@@ -33,7 +33,7 @@ class SynapseSchemaQueryBuilderTest extends SynapseBaseCase
 
         $schemas = $this->getSchemaFromDatabase();
         $this->assertCount(1, $schemas);
-        $this->assertSame([self::TEST_SCHEMA], $schemas);
+        $this->assertSame(['UTILS-TEST_QB-SCHEMA-SCHEMA'], $schemas);
     }
 
     /**

--- a/tests/Functional/Synapse/Schema/SynapseSchemaReflectionTest.php
+++ b/tests/Functional/Synapse/Schema/SynapseSchemaReflectionTest.php
@@ -65,8 +65,8 @@ class SynapseSchemaReflectionTest extends SynapseBaseCase
         $tables = $ref->getTablesNames();
         $this->assertCount(2, $tables);
         $this->assertEqualsCanonicalizing([
-            'table1',
-            'table2',
+            'TABLE1',
+            'TABLE2',
         ], $tables);
     }
 
@@ -110,8 +110,8 @@ class SynapseSchemaReflectionTest extends SynapseBaseCase
         $tables = $ref->getViewsNames();
         $this->assertCount(2, $tables);
         $this->assertEqualsCanonicalizing([
-            'view1',
-            'view2',
+            'VIEW1',
+            'VIEW2',
         ], $tables);
     }
 }

--- a/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
+++ b/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
@@ -49,7 +49,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
 
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[#utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
+            'CREATE TABLE [utils-test_qb-schema].[#utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -75,13 +75,13 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\')',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\')',
             $sql
         );
         $this->connection->executeStatement($sql);
         $ref = $this->getSynapseTableReflection();
         $this->assertNotNull($ref->getObjectId());
-        $this->assertEqualsCanonicalizing(['col1', 'col2'], $ref->getColumnsNames());
+        $this->assertEqualsCanonicalizing(['COL1', 'COL2'], $ref->getColumnsNames());
 
         $this->expectException(Exception::class);
         $this->connection->executeStatement($sql);
@@ -106,13 +106,13 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_timestamp] DATETIME2)',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2)',
             $sql
         );
         $this->connection->executeStatement($sql);
         $ref = $this->getSynapseTableReflection();
         $this->assertNotNull($ref->getObjectId());
-        $this->assertEqualsCanonicalizing(['col1', 'col2', '_timestamp'], $ref->getColumnsNames());
+        $this->assertEqualsCanonicalizing(['COL1', 'COL2', '_TIMESTAMP'], $ref->getColumnsNames());
     }
 
     public function testGetCreateTableCommandWithTimestampAndPrimaryKeys(): void
@@ -133,13 +133,13 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         );
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([pk1] INT, [col1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [col2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_timestamp] DATETIME2, PRIMARY KEY NONCLUSTERED([pk1],[col1]) NOT ENFORCED)',
+            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([PK1] INT, [COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2, PRIMARY KEY NONCLUSTERED([PK1],[COL1]) NOT ENFORCED)',
             $sql
         );
         $this->connection->executeStatement($sql);
         $ref = $this->getSynapseTableReflection();
         $this->assertNotNull($ref->getObjectId());
-        $this->assertEqualsCanonicalizing(['pk1', 'col1', 'col2', '_timestamp'], $ref->getColumnsNames());
+        $this->assertEqualsCanonicalizing(['PK1', 'COL1', 'COL2', '_TIMESTAMP'], $ref->getColumnsNames());
     }
 
     /**
@@ -341,7 +341,7 @@ EOT
 
         $ref = $this->getSynapseTableReflection();
         $this->expectException(TableNotExistsReflectionException::class);
-        $this->expectExceptionMessage('Table "utils-test_qb-schema.utils-test_test" does not exist.');
+        $this->expectExceptionMessage('Table "UTILS-TEST_QB-SCHEMA.UTILS-TEST_TEST" does not exist.');
         $ref->getObjectId();
     }
 
@@ -383,7 +383,7 @@ EOT
 
         $ref = $this->getSynapseTableReflection();
         $this->expectException(TableNotExistsReflectionException::class);
-        $this->expectExceptionMessage('Table "utils-test_qb-schema.utils-test_test" does not exist.');
+        $this->expectExceptionMessage('Table "UTILS-TEST_QB-SCHEMA.UTILS-TEST_TEST" does not exist.');
         $ref->getObjectId();
     }
 

--- a/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
+++ b/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
@@ -115,6 +115,28 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $this->assertEqualsCanonicalizing(['COL1', 'COL2', '_TIMESTAMP'], $ref->getColumnsNames());
     }
 
+    public function testGetCreateTableCommandWithTimestampOverwrite(): void
+    {
+        $this->createTestSchema();
+        $cols = [
+            SynapseColumn::createGenericColumn('col1'),
+            SynapseColumn::createGenericColumn('col2'),
+            // this timestamp type varchar is overwritten to datetime2
+            new SynapseColumn('_timestamp', new Synapse(Synapse::TYPE_NVARCHAR)),
+        ];
+        $qb = new SynapseTableQueryBuilder();
+        $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
+        $this->assertEquals(
+        // phpcs:ignore
+            'CREATE TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2)',
+            $sql
+        );
+        $this->connection->executeStatement($sql);
+        $ref = $this->getSynapseTableReflection();
+        $this->assertNotNull($ref->getObjectId());
+        $this->assertEqualsCanonicalizing(['COL1', 'COL2', '_TIMESTAMP'], $ref->getColumnsNames());
+    }
+
     public function testGetCreateTableCommandWithTimestampAndPrimaryKeys(): void
     {
         $this->createTestSchema();

--- a/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
+++ b/tests/Functional/Synapse/Table/SynapseTableQueryBuilderTest.php
@@ -49,7 +49,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
 
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[#utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
+            'CREATE TABLE [UTILS-TEST_QB-SCHEMA].[#UTILS-TEST_TEST] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\') WITH (HEAP, LOCATION = USER_DB)',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -75,7 +75,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\')',
+            'CREATE TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\')',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -106,7 +106,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         $sql = $qb->getCreateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, new ColumnCollection($cols));
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2)',
+            'CREATE TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST] ([COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2)',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -133,7 +133,7 @@ class SynapseTableQueryBuilderTest extends SynapseBaseCase
         );
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [utils-test_qb-schema].[utils-test_test] ([PK1] INT, [COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2, PRIMARY KEY NONCLUSTERED([PK1],[COL1]) NOT ENFORCED)',
+            'CREATE TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST] ([PK1] INT, [COL1] NVARCHAR(4000) NOT NULL DEFAULT \'\', [COL2] NVARCHAR(4000) NOT NULL DEFAULT \'\', [_TIMESTAMP] DATETIME2, PRIMARY KEY NONCLUSTERED([PK1],[COL1]) NOT ENFORCED)',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -330,7 +330,7 @@ EOT
         $sql = $qb->getDropTableCommand(self::TEST_SCHEMA, self::TEST_TABLE);
 
         $this->assertEquals(
-            'DROP TABLE [utils-test_qb-schema].[utils-test_test]',
+            'DROP TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST]',
             $sql
         );
 
@@ -372,7 +372,7 @@ EOT
         $sql = $qb->getRenameTableCommand(self::TEST_SCHEMA, self::TEST_TABLE, $renameTo);
 
         $this->assertEquals(
-            'RENAME OBJECT [utils-test_qb-schema].[utils-test_test] TO [newTable]',
+            'RENAME OBJECT [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST] TO [NEWTABLE]',
             $sql
         );
 
@@ -428,7 +428,7 @@ EOT
         $qb = new SynapseTableQueryBuilder();
         $sql = $qb->getTruncateTableCommand(self::TEST_SCHEMA, self::TEST_STAGING_TABLE);
         $this->assertEquals(
-            'TRUNCATE TABLE [utils-test_qb-schema].[#stagingTable]',
+            'TRUNCATE TABLE [UTILS-TEST_QB-SCHEMA].[#STAGINGTABLE]',
             $sql
         );
         $this->connection->executeStatement($sql);
@@ -469,7 +469,7 @@ EOT
         $qb = new SynapseTableQueryBuilder();
         $sql = $qb->getTruncateTableCommand(self::TEST_SCHEMA, self::TEST_TABLE);
         $this->assertEquals(
-            'TRUNCATE TABLE [utils-test_qb-schema].[utils-test_test]',
+            'TRUNCATE TABLE [UTILS-TEST_QB-SCHEMA].[UTILS-TEST_TEST]',
             $sql
         );
         $this->connection->executeStatement($sql);

--- a/tests/Functional/Synapse/Table/SynapseTableReflectionTest.php
+++ b/tests/Functional/Synapse/Table/SynapseTableReflectionTest.php
@@ -42,10 +42,10 @@ class SynapseTableReflectionTest extends SynapseBaseCase
         $ref = new SynapseTableReflection($this->connection, self::TEST_SCHEMA, self::TABLE_GENERIC);
 
         $this->assertSame([
-            'int_def',
-            'var_def',
-            'num_def',
-            '_time',
+            'INT_DEF',
+            'VAR_DEF',
+            'NUM_DEF',
+            '_TIME',
         ], $ref->getColumnsNames());
     }
 
@@ -108,7 +108,7 @@ class SynapseTableReflectionTest extends SynapseBaseCase
             SynapseQuote::quoteSingleIdentifier(self::TEST_SCHEMA),
             SynapseQuote::quoteSingleIdentifier(self::TABLE_GENERIC)
         ));
-        $this->assertSame(['_time', 'int_def'], $ref->getPrimaryKeysNames());
+        $this->assertSame(['_TIME', 'INT_DEF'], $ref->getPrimaryKeysNames());
     }
 
     public function testGetRowsCount(): void
@@ -463,10 +463,10 @@ class SynapseTableReflectionTest extends SynapseBaseCase
         $this->assertCount(2, $definitions);
 
         $col1 = $definitions[0];
-        $this->assertSame('col', $col1->getColumnName());
+        $this->assertSame('COL', $col1->getColumnName());
 
         $col2 = $definitions[1];
-        $this->assertSame('_time', $col2->getColumnName());
+        $this->assertSame('_TIME', $col2->getColumnName());
     }
 
     /**
@@ -600,8 +600,8 @@ class SynapseTableReflectionTest extends SynapseBaseCase
         $this->assertCount(1, $dependentViews);
 
         $this->assertSame([
-            'schema_name' => self::TEST_SCHEMA,
-            'name' => self::VIEW_GENERIC,
+            'schema_name' => 'UTILS-TEST_REF-TABLE-SCHEMA',
+            'name' => 'UTILS-TEST_REF-VIEW',
         ], $dependentViews[0]);
     }
 
@@ -687,7 +687,7 @@ class SynapseTableReflectionTest extends SynapseBaseCase
         ];
         yield 'HASH' => [
             'DISTRIBUTION = HASH (int_def)',
-            ['int_def'],
+            ['INT_DEF'],
         ];
         yield 'REPLICATE' => [
             'DISTRIBUTION = REPLICATE',
@@ -741,12 +741,12 @@ class SynapseTableReflectionTest extends SynapseBaseCase
         yield 'CLUSTERED INDEX' => [
             'CLUSTERED INDEX (int_def)',
             'CLUSTERED INDEX',
-            ['int_def'],
+            ['INT_DEF'],
         ];
         yield 'CLUSTERED INDEX MULTIPLE' => [
             'CLUSTERED INDEX (int_def, int_def2)',
             'CLUSTERED INDEX',
-            ['int_def', 'int_def2'],
+            ['INT_DEF', 'INT_DEF2'],
         ];
         yield 'Default' => [
             null,

--- a/tests/Functional/Synapse/View/SynapseViewReflectionTest.php
+++ b/tests/Functional/Synapse/View/SynapseViewReflectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Keboola\TableBackendUtils\Functional\Synapse\View;
 
 use Keboola\TableBackendUtils\Table\SynapseTableReflection;
+use Keboola\TableBackendUtils\Utils\CaseConverter;
 use Keboola\TableBackendUtils\View\InvalidViewDefinitionException;
 use Keboola\TableBackendUtils\View\SynapseViewReflection;
 use Tests\Keboola\TableBackendUtils\Functional\Synapse\SynapseBaseCase;
@@ -48,8 +49,8 @@ class SynapseViewReflectionTest extends SynapseBaseCase
         $this->assertCount(1, $dependentViews);
 
         $this->assertSame([
-            'schema_name' => self::TEST_SCHEMA,
-            'name' => $secondViewName,
+            'schema_name' => 'UTILS-TEST_REF-TABLE-SCHEMA',
+            'name' => 'UTILS-TEST_REF-VIEW-2',
         ], $dependentViews[0]);
     }
 

--- a/tests/Unit/Column/SynapseColumnTest.php
+++ b/tests/Unit/Column/SynapseColumnTest.php
@@ -24,7 +24,7 @@ class SynapseColumnTest extends TestCase
             'column_is_nullable' => 'true',
             'column_default' => '(NOW())',
         ]);
-        $this->assertEquals('myCol', $col->getColumnName());
+        $this->assertEquals('MYCOL', $col->getColumnName());
         $this->assertEquals('DATETIME NOT NULL DEFAULT NOW()', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('DATETIME', $col->getColumnDefinition()->getType());
         $this->assertEquals('NOW()', $col->getColumnDefinition()->getDefault());
@@ -42,7 +42,7 @@ class SynapseColumnTest extends TestCase
             'column_is_nullable' => 'true',
             'column_default' => null,
         ]);
-        $this->assertEquals('myCol', $col->getColumnName());
+        $this->assertEquals('MYCOL', $col->getColumnName());
         $this->assertEquals('NVARCHAR(2000) NOT NULL', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('NVARCHAR', $col->getColumnDefinition()->getType());
         $this->assertEquals('', $col->getColumnDefinition()->getDefault());
@@ -60,7 +60,7 @@ class SynapseColumnTest extends TestCase
             'column_is_nullable' => 'true',
             'column_default' => '((1))',
         ]);
-        $this->assertEquals('myCol', $col->getColumnName());
+        $this->assertEquals('MYCOL', $col->getColumnName());
         $this->assertEquals('DECIMAL(20,10) NOT NULL DEFAULT 1', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('DECIMAL', $col->getColumnDefinition()->getType());
         $this->assertEquals('1', $col->getColumnDefinition()->getDefault());
@@ -70,7 +70,7 @@ class SynapseColumnTest extends TestCase
     public function testCreateGenericColumn(): void
     {
         $col = SynapseColumn::createGenericColumn('myCol');
-        $this->assertEquals('myCol', $col->getColumnName());
+        $this->assertEquals('MYCOL', $col->getColumnName());
         $this->assertEquals('NVARCHAR(4000) NOT NULL DEFAULT \'\'', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('NVARCHAR', $col->getColumnDefinition()->getType());
         $this->assertEquals('\'\'', $col->getColumnDefinition()->getDefault());
@@ -80,7 +80,7 @@ class SynapseColumnTest extends TestCase
     public function testCreateTimestampColumn(): void
     {
         $col = SynapseColumn::createTimestampColumn();
-        $this->assertEquals('_timestamp', $col->getColumnName());
+        $this->assertEquals('_TIMESTAMP', $col->getColumnName());
         $this->assertEquals('DATETIME2', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('DATETIME2', $col->getColumnDefinition()->getType());
         $this->assertEquals(null, $col->getColumnDefinition()->getDefault());
@@ -90,7 +90,7 @@ class SynapseColumnTest extends TestCase
     public function testCreateTimestampColumnNonDefaultName(): void
     {
         $col = SynapseColumn::createTimestampColumn('_kbc_timestamp');
-        $this->assertEquals('_kbc_timestamp', $col->getColumnName());
+        $this->assertEquals('_KBC_TIMESTAMP', $col->getColumnName());
         $this->assertEquals('DATETIME2', $col->getColumnDefinition()->getSQLDefinition());
         $this->assertEquals('DATETIME2', $col->getColumnDefinition()->getType());
         $this->assertEquals(null, $col->getColumnDefinition()->getDefault());

--- a/tests/Unit/Table/Synapse/TableDistributionDefinitionTest.php
+++ b/tests/Unit/Table/Synapse/TableDistributionDefinitionTest.php
@@ -30,7 +30,7 @@ class TableDistributionDefinitionTest extends TestCase
     public function testValidHash(): void
     {
         $definition = new TableDistributionDefinition('HASH', ['id']);
-        self::assertSame(['id'], $definition->getDistributionColumnsNames());
+        self::assertSame(['ID'], $definition->getDistributionColumnsNames());
         self::assertSame('HASH', $definition->getDistributionName());
         self::assertTrue($definition->isHashDistribution());
     }

--- a/tests/Unit/Table/Synapse/TableIndexDefinitionTest.php
+++ b/tests/Unit/Table/Synapse/TableIndexDefinitionTest.php
@@ -26,7 +26,7 @@ class TableIndexDefinitionTest extends TestCase
     public function testValidCI(): void
     {
         $definition = new TableIndexDefinition('CLUSTERED INDEX', ['id']);
-        self::assertSame(['id'], $definition->getIndexedColumnsNames());
+        self::assertSame(['ID'], $definition->getIndexedColumnsNames());
         self::assertSame('CLUSTERED INDEX', $definition->getIndexType());
     }
 }

--- a/tests/Unit/Table/SynapseTableDefinitionTest.php
+++ b/tests/Unit/Table/SynapseTableDefinitionTest.php
@@ -31,10 +31,10 @@ class SynapseTableDefinitionTest extends TestCase
             new TableDistributionDefinition(TableDistributionDefinition::TABLE_DISTRIBUTION_ROUND_ROBIN),
             new TableIndexDefinition(TableIndexDefinition::TABLE_INDEX_TYPE_CLUSTERED_COLUMNSTORE_INDEX)
         );
-        self::assertSame('schema', $definition->getSchemaName());
-        self::assertSame('tableName', $definition->getTableName());
-        self::assertSame(['col1'], $definition->getColumnsNames());
-        self::assertSame(['pk1'], $definition->getPrimaryKeysNames());
+        self::assertSame('SCHEMA', $definition->getSchemaName());
+        self::assertSame('TABLENAME', $definition->getTableName());
+        self::assertSame(['COL1'], $definition->getColumnsNames());
+        self::assertSame(['PK1'], $definition->getPrimaryKeysNames());
         self::assertSame('ROUND_ROBIN', $definition->getTableDistribution()->getDistributionName());
         self::assertSame('CLUSTERED COLUMNSTORE INDEX', $definition->getTableIndex()->getIndexType());
         self::assertSame($columns, $definition->getColumnsDefinitions());

--- a/tests/Unit/Utils/CaseConverterTest.php
+++ b/tests/Unit/Utils/CaseConverterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\TableBackendUtils\Unit\Utils;
+
+use Keboola\TableBackendUtils\Utils\CaseConverter;
+use PHPUnit\Framework\TestCase;
+
+class CaseConverterTest extends TestCase
+{
+    public function testStringToUpper(): void
+    {
+        $string = 'testMe_man';
+        $result = CaseConverter::stringToUpper($string);
+        $this->assertSame('TESTME_MAN', $result);
+    }
+
+    public function testArrayToUpper(): void
+    {
+        $string = ['testMe_man', 'COLUMN_X', 'CoLuMn_xYZ-0'];
+        $result = CaseConverter::arrayToUpper($string);
+        $this->assertSame(['TESTME_MAN', 'COLUMN_X', 'COLUMN_XYZ-0'], $result);
+    }
+}


### PR DESCRIPTION
v Import export lib děláme porovnání názvů sloupců case sensitive přes ===, ale synapse je case insensitive, utils sů logické místo kde to globálně změnit. 
- všude se převádí stringy na uppercase (názvy sloupců, tabulke, view, schémat, primárních klíčů, indexů)
- ověřil sem že když v synapse zavolám where name = 'name' tak hledá case insensitive, funguje to všude, jediná vyjímka byla depended view, kde se hledá podle sql kterým se view vytvořilo tam je to převedené na uppercase celé aby to fungovalo, z pohledu synapse je to jedno
- když něco vracíme ze synapse (názvy tabulek, sloupců apod,…) tak se převedou zrovna na uppercase, protože ač je synapse case insensitive tak když udělám where name = 'name' tak vrátí klidně NAME a naopak, prostě ten case neunifikuje, ale nechává ho stejný jak na vstupu
- když něco zadáváme do synapse tak teď se to automaticky převádí na uppercase takže když zavolám query builder s table 'myTable'  udělá to CREATE TABLE [MYTABLE], tím se to celé unifikuje, nemá to vliv na současné data v Synapse, ale všecko nové bude uppercase, tím to usnadní match s metadaty